### PR TITLE
Fix instruction for remove

### DIFF
--- a/examples/minimal-docker-image/README.md
+++ b/examples/minimal-docker-image/README.md
@@ -21,4 +21,4 @@ or
 
 To remove the binary and the image run:
 
-    dobi binary:rm dist-img:rm
+    dobi dist-img:rm builder:rm


### PR DESCRIPTION
The remove command listed in the README.md doesn't work (for me).  I get the following warning:
> [WARN] [run:rm binary] ./dist/bin/hello container=example-hello-dre-binary Failed to remove container: No such container: example-hello-dre-binary

The command I'm suggesting here at least removes the two containers that are built by the example, but it leaves the dist/bin/hello binary in place.  Gotta dig into the code a bit to figure out how to fix that.