### PR TITLE
Remove a warning from run:rm when the container doesn't exist

### DIFF
--- a/tasks/job/remove.go
+++ b/tasks/job/remove.go
@@ -39,7 +39,7 @@ func (t *RemoveTask) Repr() string {
 
 // Run creates the host path if it doesn't already exist
 func (t *RemoveTask) Run(ctx *context.ExecuteContext) error {
-	RemoveContainer(t.logger(), ctx.Client, ContainerName(ctx, t.name))
+	RemoveContainer(t.logger(), ctx.Client, ContainerName(ctx, t.name), false)
 
 	if t.config.Artifact != "" {
 		if err := os.RemoveAll(t.config.Artifact); err != nil {

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -164,7 +164,7 @@ func (t *Task) runContainer(ctx *context.ExecuteContext) error {
 
 	chanSig := t.forwardSignals(ctx.Client, container.ID)
 	defer signal.Stop(chanSig)
-	defer RemoveContainer(t.logger(), ctx.Client, container.ID)
+	defer RemoveContainer(t.logger(), ctx.Client, container.ID, true)
 
 	_, err = ctx.Client.AttachToContainerNonBlocking(docker.AttachToContainerOptions{
 		Container:    container.ID,


### PR DESCRIPTION
Related to #13

cc @deinspanjer

Only show a warning if we expect the container to exist.