### PR TITLE
Use docker 1.10 for ci, and stop using a cache for images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,11 @@
 
 machine:
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   services:
     - docker
   environment:
-    DOCKER_API_VERSION: '1.21'
+    DOCKER_API_VERSION: '1.22'
 
 general:
   branches:
@@ -11,9 +13,7 @@ general:
 
 dependencies:
   override: [./script/ci-deps]
-  cache_directories:
-    - vendor
-    - ~/docker
+  cache_directories: [vendor]
 
 test:
   override: [./circle/dobi]

--- a/script/ci-deps
+++ b/script/ci-deps
@@ -3,25 +3,10 @@
 set -eu
 
 docker version
-mkdir -p ~/docker
+mkdir -p circle .dobi/images
 
-if [[ -e ~/docker/builder.tar ]]; then docker load -i ~/docker/builder.tar; fi
-docker images
 docker build -t dobi-dev -f dockerfiles/Dockerfile.build .
-docker save dobi-dev > ~/docker/builder.tar
-
 docker run \
     -v $PWD:/go/src/github.com/dnephin/dobi \
-    -v $PWD/circle:/go/bin \
     dobi-dev \
-    bash -ec "glide install; go install"
-
-if [[ -e ~/docker/linter.tar ]]; then docker load -i ~/docker/linter.tar; fi
-docker images
-./circle/dobi linter
-docker save dobi-linter:dobi-ubuntu > ~/docker/linter.tar
-
-if [[ -e ~/docker/docs.tar ]]; then docker load -i ~/docker/docs.tar; fi
-docker images
-./circle/dobi docs-img
-docker save dobi-docs-dev:dobi-ubuntu > ~/docker/docs.tar
+    bash -ec "glide install; go build -o circle/dobi ."


### PR DESCRIPTION
The image cache is not working and making the build slower.