### PR TITLE
Implement capture variables

### DIFF
--- a/tasks/job/actions_test.go
+++ b/tasks/job/actions_test.go
@@ -1,0 +1,18 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCapture(t *testing.T) {
+	variable, err := parseCapture("capture(FOO)")
+	assert.Nil(t, err)
+	assert.Equal(t, "FOO", variable)
+}
+
+func TestParseCaptureInvalid(t *testing.T) {
+	_, err := parseCapture("capture")
+	assert.Error(t, err)
+}

--- a/tasks/job/capture.go
+++ b/tasks/job/capture.go
@@ -1,0 +1,59 @@
+package job
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dnephin/dobi/config"
+	"github.com/dnephin/dobi/logging"
+	"github.com/dnephin/dobi/tasks/context"
+	"github.com/dnephin/dobi/tasks/task"
+	"github.com/dnephin/dobi/tasks/types"
+)
+
+func newCaptureTask(variable string) types.TaskBuilder {
+	return func(name task.Name, conf config.Resource) types.Task {
+		buffer := bytes.NewBufferString("")
+		return &captureTask{
+			runTask: &Task{
+				name:      name,
+				config:    conf.(*config.JobConfig),
+				outStream: buffer,
+			},
+			variable: variable,
+			buffer:   buffer,
+		}
+	}
+}
+
+type captureTask struct {
+	types.NoStop
+	runTask  *Task
+	variable string
+	buffer   *bytes.Buffer
+}
+
+// Name returns the name of the task
+func (t *captureTask) Name() task.Name {
+	return t.runTask.name
+}
+
+// Repr formats the task for logging
+func (t *captureTask) Repr() string {
+	return fmt.Sprintf("%s capture %s", t.runTask.name.Format("job"), t.variable)
+}
+
+// Run the job to capture the output in a variable
+func (t *captureTask) Run(ctx *context.ExecuteContext, _ bool) (bool, error) {
+	// Always pass depsModified as true so that the task runs and is never cached
+	modified, err := t.runTask.Run(ctx, true)
+	if err != nil {
+		return modified, err
+	}
+
+	out := strings.TrimSpace(t.buffer.String())
+	logging.ForTask(t).Debug("Setting %q to: %s", t.variable, out)
+	return true, os.Setenv(t.variable, out)
+}


### PR DESCRIPTION
Fixes #35

This will need some more docs to explain how it works, but I'll put a brief example here.

Say you have a job called `version` that prints the version to stdout, you would capture it in an env variable called `APP_VERSION` using:

```
version:capture(APP_VERSION)
```

This can be used in an alias, and any tasks following it will have the `APP_VERSION` environment variable set to the `stdout` of the `version` job.