### PR TITLE
labels

### DIFF
--- a/config/job.go
+++ b/config/job.go
@@ -81,6 +81,9 @@ type JobConfig struct {
 	// type: list of device specs
 	// example: ``{Host: /dev/fb0, Container: /dev/fb0, Permissions: rwm}``
 	Devices []Device
+	// Labels sets the labels of the running job container
+	// type: map of string keys to string values
+	Labels map[string]string
 	dependent
 	describable
 }

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -239,6 +239,7 @@ func (t *Task) createOptions(ctx *context.ExecuteContext, name string) docker.Cr
 			Tty:          interactive,
 			AttachStdin:  interactive,
 			StdinOnce:    interactive,
+			Labels:       t.config.Labels,
 			AttachStderr: true,
 			AttachStdout: true,
 			Env:          t.config.Env,


### PR DESCRIPTION
compose services have labels, dobi jobs should also have it
deployments like kubernetes also have the concept of labels 

