### PR TITLE
Support jobs without binds

### DIFF
--- a/cmd/dobi.go
+++ b/cmd/dobi.go
@@ -25,11 +25,12 @@ var (
 )
 
 type dobiOptions struct {
-	filename string
-	verbose  bool
-	quiet    bool
-	tasks    []string
-	version  bool
+	filename    string
+	verbose     bool
+	quiet       bool
+	noBindMount bool
+	tasks       []string
+	version     bool
 }
 
 // NewRootCommand returns a new root command
@@ -57,6 +58,8 @@ func NewRootCommand() *cobra.Command {
 	flags.StringVarP(&opts.filename, "filename", "f", "dobi.yaml", "Path to config file")
 	flags.BoolVarP(&opts.verbose, "verbose", "v", false, "Verbose")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Quiet")
+	flags.BoolVar(&opts.noBindMount, "no-bind-mount", false,
+		"Provide mounts as a layer in an image instead of a bind mount")
 	flags.BoolVar(&opts.version, "version", false, "Print version and exit")
 
 	flags.SetInterspersed(false)
@@ -84,10 +87,11 @@ func runDobi(opts dobiOptions) error {
 	}
 
 	return tasks.Run(tasks.RunOptions{
-		Client: client,
-		Config: conf,
-		Tasks:  opts.tasks,
-		Quiet:  opts.quiet,
+		Client:    client,
+		Config:    conf,
+		Tasks:     opts.tasks,
+		Quiet:     opts.quiet,
+		BindMount: !opts.noBindMount,
 	})
 }
 

--- a/cmd/dobi.go
+++ b/cmd/dobi.go
@@ -58,7 +58,10 @@ func NewRootCommand() *cobra.Command {
 	flags.StringVarP(&opts.filename, "filename", "f", "dobi.yaml", "Path to config file")
 	flags.BoolVarP(&opts.verbose, "verbose", "v", false, "Verbose")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Quiet")
-	flags.BoolVar(&opts.noBindMount, "no-bind-mount", false,
+	flags.BoolVar(
+		&opts.noBindMount,
+		"no-bind-mount",
+		defaultBoolValue("DOBI_NO_BIND_MOUNT"),
 		"Provide mounts as a layer in an image instead of a bind mount")
 	flags.BoolVar(&opts.version, "version", false, "Print version and exit")
 
@@ -126,4 +129,8 @@ func buildClient() (client.DockerClient, error) {
 
 func printVersion() {
 	fmt.Printf("dobi version %v (build: %v, date: %s)\n", version, gitsha, buildDate)
+}
+
+func defaultBoolValue(key string) bool {
+	return os.Getenv(key) != ""
 }

--- a/config/alias.go
+++ b/config/alias.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 )
 
 // AliasConfig An **alias** resource is a list of other tasks which will be run
@@ -41,7 +40,7 @@ func (c *AliasConfig) String() string {
 }
 
 // Resolve resolves variables in the resource
-func (c *AliasConfig) Resolve(env *execenv.ExecEnv) (Resource, error) {
+func (c *AliasConfig) Resolve(_ Resolver) (Resource, error) {
 	copy := *c
 	return &copy, nil
 }

--- a/config/compose.go
+++ b/config/compose.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 )
 
 // ComposeConfig A **compose** resource runs ``docker-compose`` to create an
@@ -60,14 +59,14 @@ func (c *ComposeConfig) String() string {
 }
 
 // Resolve resolves variables in the resource
-func (c *ComposeConfig) Resolve(env *execenv.ExecEnv) (Resource, error) {
+func (c *ComposeConfig) Resolve(resolver Resolver) (Resource, error) {
 	conf := *c
 	var err error
-	conf.Files, err = env.ResolveSlice(c.Files)
+	conf.Files, err = resolver.ResolveSlice(c.Files)
 	if err != nil {
 		return &conf, err
 	}
-	conf.Project, err = env.Resolve(c.Project)
+	conf.Project, err = resolver.Resolve(c.Project)
 	return &conf, err
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"testing"
 
-	"github.com/dnephin/dobi/execenv"
 	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,18 +20,29 @@ func TestSorted(t *testing.T) {
 }
 
 func TestResourceResolveDoesNotMutate(t *testing.T) {
-	env := execenv.NewExecEnv("execid", "project", ".")
+	resolver := &fakeResolver{}
 
 	for name, fromConfigFunc := range resourceTypeRegistry {
 		value := make(map[string]interface{})
 		resource, err := fromConfigFunc(name, value)
 		assert.Nil(t, err)
-		resolved, err := resource.Resolve(env)
+		resolved, err := resource.Resolve(resolver)
 		assert.Nil(t, err)
 		assert.True(t, resource != resolved,
 			"Expected different pointers for %q: %p, %p",
 			name, resource, resolved)
 	}
+}
+
+type fakeResolver struct {
+}
+
+func (r *fakeResolver) Resolve(tmpl string) (string, error) {
+	return tmpl, nil
+}
+
+func (r *fakeResolver) ResolveSlice(tmpls []string) ([]string, error) {
+	return tmpls, nil
 }
 
 // FIXME: not a full config

--- a/config/env.go
+++ b/config/env.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 )
 
 // EnvConfig An **env** resource provides environment variables to **job** and
@@ -42,16 +41,16 @@ func (c *EnvConfig) Validate(pth.Path, *Config) *pth.Error {
 }
 
 // Resolve resolves variables in the config
-func (c *EnvConfig) Resolve(env *execenv.ExecEnv) (Resource, error) {
+func (c *EnvConfig) Resolve(resolver Resolver) (Resource, error) {
 	conf := *c
 	var err error
 
-	conf.Files, err = env.ResolveSlice(c.Files)
+	conf.Files, err = resolver.ResolveSlice(c.Files)
 	if err != nil {
 		return &conf, err
 	}
 
-	conf.Variables, err = env.ResolveSlice(c.Variables)
+	conf.Variables, err = resolver.ResolveSlice(c.Variables)
 	return &conf, err
 }
 

--- a/config/image.go
+++ b/config/image.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -114,21 +113,21 @@ func (c *ImageConfig) String() string {
 }
 
 // Resolve resolves variables in the resource
-func (c *ImageConfig) Resolve(env *execenv.ExecEnv) (Resource, error) {
+func (c *ImageConfig) Resolve(resolver Resolver) (Resource, error) {
 	conf := *c
 	var err error
-	conf.Tags, err = env.ResolveSlice(c.Tags)
+	conf.Tags, err = resolver.ResolveSlice(c.Tags)
 	if err != nil {
 		return &conf, err
 	}
 
-	conf.Image, err = env.Resolve(c.Image)
+	conf.Image, err = resolver.Resolve(c.Image)
 	if err != nil {
 		return &conf, err
 	}
 
 	for key, value := range c.Args {
-		conf.Args[key], err = env.Resolve(value)
+		conf.Args[key], err = resolver.Resolve(value)
 		if err != nil {
 			return &conf, err
 		}

--- a/config/job.go
+++ b/config/job.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 	shlex "github.com/kballard/go-shellquote"
 )
 
@@ -164,22 +163,22 @@ func (c *JobConfig) String() string {
 }
 
 // Resolve resolves variables in the resource
-func (c *JobConfig) Resolve(env *execenv.ExecEnv) (Resource, error) {
+func (c *JobConfig) Resolve(resolver Resolver) (Resource, error) {
 	conf := *c
 	var err error
-	conf.Env, err = env.ResolveSlice(c.Env)
+	conf.Env, err = resolver.ResolveSlice(c.Env)
 	if err != nil {
 		return &conf, err
 	}
-	conf.WorkingDir, err = env.Resolve(c.WorkingDir)
+	conf.WorkingDir, err = resolver.Resolve(c.WorkingDir)
 	if err != nil {
 		return &conf, err
 	}
-	conf.User, err = env.Resolve(c.User)
+	conf.User, err = resolver.Resolve(c.User)
 	if err != nil {
 		return &conf, err
 	}
-	conf.NetMode, err = env.Resolve(c.NetMode)
+	conf.NetMode, err = resolver.Resolve(c.NetMode)
 	return &conf, err
 }
 

--- a/config/mount.go
+++ b/config/mount.go
@@ -90,6 +90,11 @@ func (c *MountConfig) String() string {
 	return fmt.Sprintf("Create %s to be mounted at %q", mount, c.Path)
 }
 
+// IsBind returns true if the mount is a bind mount to a host directory
+func (c *MountConfig) IsBind() bool {
+	return c.Bind != ""
+}
+
 // Resolve resolves variables in the resource
 func (c *MountConfig) Resolve(resolver Resolver) (Resource, error) {
 	conf := *c

--- a/config/mount.go
+++ b/config/mount.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 	"github.com/dnephin/dobi/utils/fs"
 )
 
@@ -92,14 +91,14 @@ func (c *MountConfig) String() string {
 }
 
 // Resolve resolves variables in the resource
-func (c *MountConfig) Resolve(env *execenv.ExecEnv) (Resource, error) {
+func (c *MountConfig) Resolve(resolver Resolver) (Resource, error) {
 	conf := *c
 	var err error
-	conf.Path, err = env.Resolve(c.Path)
+	conf.Path, err = resolver.Resolve(c.Path)
 	if err != nil {
 		return &conf, err
 	}
-	conf.Name, err = env.Resolve(c.Name)
+	conf.Name, err = resolver.Resolve(c.Name)
 	if err != nil {
 		return &conf, err
 	}

--- a/config/resource.go
+++ b/config/resource.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	pth "github.com/dnephin/configtf/path"
-	"github.com/dnephin/dobi/execenv"
 	"github.com/dnephin/dobi/logging"
 	"github.com/pkg/errors"
 )
@@ -11,7 +10,7 @@ import (
 type Resource interface {
 	Dependencies() []string
 	Validate(pth.Path, *Config) *pth.Error
-	Resolve(*execenv.ExecEnv) (Resource, error)
+	Resolve(Resolver) (Resource, error)
 	Describe() string
 	CategoryTags() []string
 	String() string
@@ -70,4 +69,10 @@ type Dependent struct {
 // Dependencies returns the list of tasks
 func (d *Dependent) Dependencies() []string {
 	return d.Depends
+}
+
+// Resolver is an interface for a type that returns values for variables
+type Resolver interface {
+	Resolve(tmpl string) (string, error)
+	ResolveSlice(tmpls []string) ([]string, error)
 }

--- a/config/types.go
+++ b/config/types.go
@@ -59,10 +59,15 @@ func (p *PathGlobs) all() ([]string, error) {
 func (p *PathGlobs) Paths() []string {
 	all, err := p.all()
 	if err != nil {
-		// Error hould have already been returned during Validate()
+		// Error should have already been returned during Validate()
 		panic(err)
 	}
 	return all
+}
+
+// Globs returns the raw list of path globs
+func (p *PathGlobs) Globs() []string {
+	return p.globs
 }
 
 // Empty returns true if there are no globs

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -118,7 +118,7 @@ job=release-version:
 
 job=docs-build:
     use: docs-img
-    artifact: ./docs/build/html
+    artifact: ./docs/build/html.tar.gz
     mounts: [source]
     command: docs/script/build
 
@@ -167,7 +167,9 @@ job=test-examples:
     env:
       - 'DOCKER_API_VERSION={env.DOCKER_API_VERSION:}'
       - 'COMPOSE_API_VERSION={env.DOCKER_API_VERSION:}'
+      - 'DOBI_NO_BIND_MOUNT={env.DOBI_NO_BIND_MOUNT:}'
       - 'DOBI_EXAMPLE={env.DOBI_EXAMPLE:}'
+    artifact: _results/
 
 job=examples-shell:
     use: example-tester

--- a/docs/script/build
+++ b/docs/script/build
@@ -5,3 +5,4 @@ set -eu
 mkdir -p docs/gen/config
 go run docs/script/configtypes.go
 sphinx-build -b html -d docs/doctrees docs/source docs/build/html
+tar -czf docs/build/html.tar.gz -C docs/build/html .

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3ea50baaca1fcd7eafbce6769e082a5c9ede441e0ff9659c497ed639161e663c
-updated: 2017-10-19T16:47:00.048293267Z
+hash: d278812d200359071d4ed8687b727eba8d8c66a171669ab34cad1fb0a52272d7
+updated: 2017-10-20T20:54:03.439105933Z
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
@@ -15,6 +15,7 @@ imports:
 - name: github.com/docker/cli
   version: 03a46a66bd0629b5097289c6180e7a72a0efd823
   subpackages:
+  - cli/command/image/build
   - opts
 - name: github.com/docker/docker
   version: f7ce35f47b1b8e029d7e572ef333cabba1b08e5b
@@ -30,6 +31,8 @@ imports:
   - api/types/swarm
   - api/types/swarm/runtime
   - api/types/versions
+  - builder/dockerignore
+  - builder/remotecontext/git
   - opts
   - pkg/archive
   - pkg/fileutils
@@ -41,11 +44,16 @@ imports:
   - pkg/longpath
   - pkg/mount
   - pkg/pools
+  - pkg/progress
   - pkg/promise
   - pkg/stdcopy
+  - pkg/streamformatter
+  - pkg/stringid
+  - pkg/symlink
   - pkg/system
   - pkg/term
   - pkg/term/windows
+  - pkg/urlutil
 - name: github.com/docker/go-connections
   version: 3ede32e2033de7505e6500d6c868c2b9ed9f169d
   subpackages:
@@ -66,6 +74,8 @@ imports:
   - gomock
 - name: github.com/gotestyourself/gotestyourself
   version: 5aac0d55ecf82c21113b05a175041f7a24a56ce7
+  subpackages:
+  - fs
 - name: github.com/hashicorp/go-cleanhttp
   version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/inconshreveable/mousetrap
@@ -93,10 +103,10 @@ imports:
   - libcontainer/system
   - libcontainer/user
 - name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/renstrom/dedent
   version: 020d11c3b9c0c7a3c2efcc8e5cf5b9ef7bcea21f
-- name: github.com/sirupsen/logrus
+- name: github.com/Sirupsen/logrus
   version: 51dc0fc64317a2861273909081f9c315786533eb
 - name: github.com/sirupsen/logrus
   version: 51dc0fc64317a2861273909081f9c315786533eb
@@ -127,6 +137,10 @@ imports:
   subpackages:
   - unix
   - windows
+- name: golang.org/x/time
+  version: 6dc17368e09b0e8634d71cac8168d853e869a0c7
+  subpackages:
+  - rate
 - name: gopkg.in/yaml.v2
   version: 3b4ad1db5b2a649883ff3782f5f9f6fb52be71af
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,5 @@ import:
 - package: github.com/docker/cli
 - package: github.com/gotestyourself/gotestyourself
   version: ^1.2.0
+- package: github.com/pkg/errors
+  version: ^0.8.0

--- a/internal/test/config/fakeresource.go
+++ b/internal/test/config/fakeresource.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/dnephin/configtf/path"
 	"github.com/dnephin/dobi/config"
-	"github.com/dnephin/dobi/execenv"
 )
 
 // FakeResource is a fake used for testing
@@ -18,7 +17,7 @@ func (r *FakeResource) Validate(path path.Path, config *config.Config) *path.Err
 }
 
 // Resolve is a no-op
-func (r *FakeResource) Resolve(env *execenv.ExecEnv) (config.Resource, error) {
+func (r *FakeResource) Resolve(env config.Resolver) (config.Resource, error) {
 	return r, nil
 }
 

--- a/script/build
+++ b/script/build
@@ -10,3 +10,8 @@ gox \
     -output="/go/bin/dobi-{{.OS}}" \
     -arch="amd64" -os="$oslist" \
     .
+
+if [[ -e /go/bin/dobi-linux ]]; then
+    echo "linking dobi to dobi-linux"
+    ln -sf dobi-linux /go/bin/dobi || true
+fi

--- a/tasks/client/iface.go
+++ b/tasks/client/iface.go
@@ -21,6 +21,7 @@ type DockerClient interface {
 	RemoveContainer(docker.RemoveContainerOptions) error
 	StartContainer(string, *docker.HostConfig) error
 	WaitContainer(string) (int, error)
+	DownloadFromContainer(id string, opts docker.DownloadFromContainerOptions) error
 
 	CreateVolume(opts docker.CreateVolumeOptions) (*docker.Volume, error)
 	RemoveVolume(name string) error

--- a/tasks/client/mock_iface.go
+++ b/tasks/client/mock_iface.go
@@ -180,6 +180,18 @@ func (_mr *MockDockerClientMockRecorder) WaitContainer(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "WaitContainer", reflect.TypeOf((*MockDockerClient)(nil).WaitContainer), arg0)
 }
 
+// DownloadFromContainer mocks base method
+func (_m *MockDockerClient) DownloadFromContainer(id string, opts go_dockerclient.DownloadFromContainerOptions) error {
+	ret := _m.ctrl.Call(_m, "DownloadFromContainer", id, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DownloadFromContainer indicates an expected call of DownloadFromContainer
+func (_mr *MockDockerClientMockRecorder) DownloadFromContainer(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "DownloadFromContainer", reflect.TypeOf((*MockDockerClient)(nil).DownloadFromContainer), arg0, arg1)
+}
+
 // CreateVolume mocks base method
 func (_m *MockDockerClient) CreateVolume(opts go_dockerclient.CreateVolumeOptions) (*go_dockerclient.Volume, error) {
 	ret := _m.ctrl.Call(_m, "CreateVolume", opts)

--- a/tasks/context/collection.go
+++ b/tasks/context/collection.go
@@ -5,6 +5,8 @@ import (
 )
 
 // ResourceCollection holds resource configs that are used by other resources
+// TODO: this type can be removed if config.Config is changed to store resources
+// grouped by type, instead of as a single map
 type ResourceCollection struct {
 	mounts map[string]*config.MountConfig
 	images map[string]*config.ImageConfig

--- a/tasks/context/execcontext.go
+++ b/tasks/context/execcontext.go
@@ -17,7 +17,7 @@ type ExecuteContext struct {
 	authConfigs *docker.AuthConfigurations
 	WorkingDir  string
 	Env         *execenv.ExecEnv
-	Quiet       bool
+	Settings    Settings
 }
 
 // IsModified returns true if any of the tasks named in names has been modified
@@ -63,7 +63,7 @@ func NewExecuteContext(
 	config *config.Config,
 	client client.DockerClient,
 	execEnv *execenv.ExecEnv,
-	quiet bool,
+	settings Settings,
 ) *ExecuteContext {
 
 	authConfigs, err := docker.NewAuthConfigurationsFromDockerCfg()
@@ -78,6 +78,6 @@ func NewExecuteContext(
 		Client:      client,
 		authConfigs: authConfigs,
 		Env:         execEnv,
-		Quiet:       quiet,
+		Settings:    settings,
 	}
 }

--- a/tasks/context/settings.go
+++ b/tasks/context/settings.go
@@ -1,0 +1,13 @@
+package context
+
+// Settings are flags that can be set by a user to change the behaviour of some
+// tasks
+type Settings struct {
+	Quiet     bool
+	BindMount bool
+}
+
+// NewSettings returns a new Settings
+func NewSettings(quiet bool, bindMount bool) Settings {
+	return Settings{Quiet: quiet, BindMount: bindMount}
+}

--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -85,7 +85,7 @@ func buildImage(ctx *context.ExecuteContext, t *Task) error {
 			ContextDir:     t.config.Context,
 			OutputStream:   out,
 			RawJSONStream:  true,
-			SuppressOutput: ctx.Quiet,
+			SuppressOutput: ctx.Settings.Quiet,
 			AuthConfigs:    ctx.GetAuthConfigs(),
 		})
 	}); err != nil {

--- a/tasks/job/build.go
+++ b/tasks/job/build.go
@@ -1,76 +1,98 @@
 package job
 
 import (
-	"archive/tar"
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/Microsoft/go-winio/archive/tar"
 	"github.com/dnephin/dobi/config"
+	"github.com/dnephin/dobi/tasks/client"
 	"github.com/dnephin/dobi/tasks/context"
 	"github.com/dnephin/dobi/tasks/image"
+	"github.com/docker/cli/cli/command/image/build"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"sort"
 )
 
 func (t *Task) runWithBuildAndCopy(ctx *context.ExecuteContext) error {
-	imageID, err := t.buildImageWithMounts(ctx)
-	if err != nil {
+	name := containerName(ctx, t.name.Resource())
+	imageName := fmt.Sprintf("%s:job-%s",
+		ctx.Resources.Image(t.config.Use).Image, name)
+
+	if err := t.buildImageWithMounts(ctx, imageName); err != nil {
 		return err
 	}
+	defer removeImage(t.logger(), ctx.Client, imageName)
 
-	name := containerName(ctx, t.name.Resource())
-	options := t.createOptions(ctx, name, imageID)
 	defer removeContainerWithLogging(t.logger(), ctx.Client, name)
-
+	options := t.createOptions(ctx, name, imageName)
 	if err := t.runContainer(ctx, options); err != nil {
 		return err
 	}
-	return copyFilesToHost(ctx, name)
+	return copyFilesToHost(t.logger(), ctx, t.config, name)
 }
 
-func (t *Task) buildImageWithMounts(ctx *context.ExecuteContext) (string, error) {
-	dockerfile := buildDockerfileWithCopy(ctx, t.config)
-	buildContext, err := buildTarFromDockerfile(dockerfile)
-	if err != nil {
-		return "", err
-	}
+func (t *Task) buildImageWithMounts(ctx *context.ExecuteContext, imageName string) error {
+	baseImage := image.GetImageName(ctx, ctx.Resources.Image(t.config.Use))
+	mounts := getBindMounts(ctx, t.config)
 
-	err = image.Stream(os.Stdout, func(out io.Writer) error {
+	dockerfile := buildDockerfileWithCopy(baseImage, mounts)
+	buildContext, dockerfileName, err := buildTarContext(dockerfile, mounts)
+	if err != nil {
+		return err
+	}
+	return image.Stream(os.Stdout, func(out io.Writer) error {
 		opts := buildImageOptions(ctx, out)
 		opts.InputStream = buildContext
+		opts.Name = imageName
+		opts.Dockerfile = dockerfileName
 		return ctx.Client.BuildImage(opts)
 	})
-	// TODO: imageID
-	return "", err
 }
 
-func buildDockerfileWithCopy(ctx *context.ExecuteContext, cfg *config.JobConfig) *bytes.Buffer {
-	baseImage := image.GetImageName(ctx, ctx.Resources.Image(cfg.Use))
+func getBindMounts(ctx *context.ExecuteContext, cfg *config.JobConfig) []config.MountConfig {
+	mounts := []config.MountConfig{}
+	ctx.Resources.EachMount(cfg.Mounts, func(_ string, mount *config.MountConfig) {
+		if !mount.IsBind() {
+			return
+		}
+		mounts = append(mounts, *mount)
+	})
+	return mounts
+}
+
+func buildDockerfileWithCopy(baseImage string, mounts []config.MountConfig) *bytes.Buffer {
 	buf := bytes.NewBufferString("FROM " + baseImage + "\n")
 	// TODO: sort by shortest path first
-	for _, mountName := range cfg.Mounts {
-		mount := ctx.Resources.Mount(mountName)
-		if !mount.IsBind() {
-			continue
-		}
+	for _, mount := range mounts {
 		buf.WriteString(fmt.Sprintf("COPY %s %s\n", mount.Bind, mount.Path))
 	}
 	return buf
 }
 
-func buildTarFromDockerfile(dockerfile *bytes.Buffer) (io.Reader, error) {
-	buf := new(bytes.Buffer)
-	tarWriter := tar.NewWriter(buf)
-	if err := tarWriter.WriteHeader(&tar.Header{
-		Name: "Dockerfile",
-		Mode: 644,
-		Size: int64(dockerfile.Len()),
-	}); err != nil {
-		return nil, err
+func buildTarContext(
+	dockerfile io.Reader,
+	mounts []config.MountConfig,
+) (io.Reader, string, error) {
+	paths := []string{}
+	for _, mount := range mounts {
+		paths = append(paths, mount.Bind)
 	}
-	_, err := io.Copy(tarWriter, dockerfile)
-	return buf, err
+	buildCtx, err := archive.TarWithOptions(".", &archive.TarOptions{
+		IncludeFiles: paths,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return build.AddDockerfileToBuildContext(ioutil.NopCloser(dockerfile), buildCtx)
 }
 
 func buildImageOptions(ctx *context.ExecuteContext, out io.Writer) docker.BuildImageOptions {
@@ -80,10 +102,169 @@ func buildImageOptions(ctx *context.ExecuteContext, out io.Writer) docker.BuildI
 		RawJSONStream:  true,
 		SuppressOutput: ctx.Settings.Quiet,
 		AuthConfigs:    ctx.GetAuthConfigs(),
-		Dockerfile:     "Dockerfile",
 	}
 }
 
-func copyFilesToHost(ctx *context.ExecuteContext, containerID string) error {
+func removeImage(logger *log.Entry, client client.DockerClient, imageID string) {
+	if err := client.RemoveImage(imageID); err != nil {
+		logger.Warnf("failed to remove %q: %s", imageID, err)
+	}
+}
+
+// TODO: optimize by performing only one copy from container per directory
+// if there are overlapping artifact paths
+func copyFilesToHost(
+	logger *log.Entry,
+	ctx *context.ExecuteContext,
+	cfg *config.JobConfig,
+	containerID string,
+) error {
+	mounts := getBindMounts(ctx, cfg)
+	for _, artifact := range cfg.Artifact.Globs() {
+		artifactPath, err := getArtifactPath(ctx.WorkingDir, artifact, mounts)
+		if err != nil {
+			return err
+		}
+		logger.Debugf("Copying %s from container directory %s",
+			artifact, artifactPath.containerDir())
+		buf := new(bytes.Buffer)
+		opts := docker.DownloadFromContainerOptions{
+			Path:         artifactPath.containerDir(),
+			OutputStream: buf,
+		}
+		if err := ctx.Client.DownloadFromContainer(containerID, opts); err != nil {
+			return err
+		}
+		if err := unpack(buf, artifactPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// artifactPath stores the absolute paths of an artifact
+type artifactPath struct {
+	mountBind    string
+	mountPath    string
+	artifactGlob string
+}
+
+func newArtifactPath(mountBind, mountPath, glob string) artifactPath {
+	return artifactPath{
+		mountBind:    mountBind,
+		mountPath:    mountPath,
+		artifactGlob: glob,
+	}
+}
+
+// containerDir used as the path for a container copy API call
+func (p artifactPath) containerDir() string {
+	return filepath.Dir(p.containerGlob())
+}
+
+// containerGlob used to match files in the archive returned by the API
+func (p artifactPath) containerGlob() string {
+	return rebasePath(p.artifactGlob, p.mountBind, p.mountPath)
+}
+
+// the host prefix to prepend to the archive paths
+func (p artifactPath) hostBase() string {
+	return p.mountBind
+}
+
+// the container path to strip from archive paths
+// func (p artifactPath) containerPrefix() string { }
+
+func getArtifactPath(
+	workingDir string,
+	glob string,
+	mounts []config.MountConfig,
+) (artifactPath, error) {
+	absGlob := filepathJoinPreserveDirectorySlash(workingDir, glob)
+
+	sortMountsByLongestBind(mounts)
+	for _, mount := range mounts {
+		absBindPath := filepathJoinPreserveDirectorySlash(workingDir, mount.Bind)
+
+		if !hasPathPrefix(filepath.Dir(absGlob), absBindPath) {
+			continue
+		}
+		return newArtifactPath(absBindPath, mount.Path, absGlob), nil
+	}
+	return artifactPath{}, errors.Errorf("no mount found for artifact %s", glob)
+}
+
+func sortMountsByLongestBind(mounts []config.MountConfig) {
+	sort.Slice(mounts, func(i, j int) bool {
+		return mounts[i].Bind >= mounts[j].Bind
+	})
+}
+
+// hasPathPrefix returns true if path is under the directory prefix
+func hasPathPrefix(path, prefix string) bool {
+	sep := string(filepath.Separator)
+	pathParts := strings.Split(filepath.Clean(path), sep)
+	prefixParts := strings.Split(filepath.Clean(prefix), sep)
+
+	if len(prefixParts) > len(pathParts) {
+		return false
+	}
+	for index, prefixItem := range prefixParts {
+		if prefixItem != pathParts[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func filepathJoinPreserveDirectorySlash(elem ...string) string {
+	sep := string(filepath.Separator)
+	trailingSlash := ""
+	if strings.HasSuffix(elem[len(elem)-1], sep) {
+		trailingSlash = sep
+	}
+	return filepath.Join(elem...) + trailingSlash
+}
+
+func rebasePath(path, oldPrefix, newPrefix string) string {
+	return filepathJoinPreserveDirectorySlash(
+		newPrefix,
+		strings.TrimPrefix(path, oldPrefix))
+}
+
+func unpack(source io.Reader, path artifactPath) error {
+	tarReader := tar.NewReader(source)
+
+	for {
+		header, err := tarReader.Next()
+		switch {
+		case err == io.EOF:
+			return nil
+		case err != nil:
+			return err
+		}
+
+		// TODO: remove debug
+		fmt.Println("Archive Path: ", header.Name)
+		match, err := filepath.Match(path.containerGlob(), header.Name)
+		switch {
+		case err != nil:
+			return err
+		case !match:
+			continue
+		}
+
+		if err := createFromTar(tarReader, header, path); err != nil {
+			return err
+		}
+	}
+}
+
+// create files and directories from tar archive entries
+func createFromTar(tarReader *tar.Reader, header *tar.Header, path artifactPath) error {
+	// If directory, create it if it doesn't exist
+
+	// If file, create the parent directories if they don't exist
+	// then create the file and write to it
 	return nil
 }

--- a/tasks/job/build.go
+++ b/tasks/job/build.go
@@ -1,12 +1,20 @@
 package job
 
 import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dnephin/dobi/config"
 	"github.com/dnephin/dobi/tasks/context"
 	"github.com/dnephin/dobi/tasks/image"
+	"github.com/fsouza/go-dockerclient"
 )
 
 func (t *Task) runWithBuildAndCopy(ctx *context.ExecuteContext) error {
-	imageID, err := buildImageWithMounts(ctx)
+	imageID, err := t.buildImageWithMounts(ctx)
 	if err != nil {
 		return err
 	}
@@ -21,9 +29,59 @@ func (t *Task) runWithBuildAndCopy(ctx *context.ExecuteContext) error {
 	return copyFilesToHost(ctx, name)
 }
 
-func buildImageWithMounts(ctx *context.ExecuteContext) (string, error) {
-	imageName := image.GetImageName(ctx, ctx.Resources.Image(t.config.Use))
-	return "", nil
+func (t *Task) buildImageWithMounts(ctx *context.ExecuteContext) (string, error) {
+	dockerfile := buildDockerfileWithCopy(ctx, t.config)
+	buildContext, err := buildTarFromDockerfile(dockerfile)
+	if err != nil {
+		return "", err
+	}
+
+	err = image.Stream(os.Stdout, func(out io.Writer) error {
+		opts := buildImageOptions(ctx, out)
+		opts.InputStream = buildContext
+		return ctx.Client.BuildImage(opts)
+	})
+	// TODO: imageID
+	return "", err
+}
+
+func buildDockerfileWithCopy(ctx *context.ExecuteContext, cfg *config.JobConfig) *bytes.Buffer {
+	baseImage := image.GetImageName(ctx, ctx.Resources.Image(cfg.Use))
+	buf := bytes.NewBufferString("FROM " + baseImage + "\n")
+	// TODO: sort by shortest path first
+	for _, mountName := range cfg.Mounts {
+		mount := ctx.Resources.Mount(mountName)
+		if !mount.IsBind() {
+			continue
+		}
+		buf.WriteString(fmt.Sprintf("COPY %s %s\n", mount.Bind, mount.Path))
+	}
+	return buf
+}
+
+func buildTarFromDockerfile(dockerfile *bytes.Buffer) (io.Reader, error) {
+	buf := new(bytes.Buffer)
+	tarWriter := tar.NewWriter(buf)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "Dockerfile",
+		Mode: 644,
+		Size: int64(dockerfile.Len()),
+	}); err != nil {
+		return nil, err
+	}
+	_, err := io.Copy(tarWriter, dockerfile)
+	return buf, err
+}
+
+func buildImageOptions(ctx *context.ExecuteContext, out io.Writer) docker.BuildImageOptions {
+	return docker.BuildImageOptions{
+		RmTmpContainer: true,
+		OutputStream:   out,
+		RawJSONStream:  true,
+		SuppressOutput: ctx.Settings.Quiet,
+		AuthConfigs:    ctx.GetAuthConfigs(),
+		Dockerfile:     "Dockerfile",
+	}
 }
 
 func copyFilesToHost(ctx *context.ExecuteContext, containerID string) error {

--- a/tasks/job/build.go
+++ b/tasks/job/build.go
@@ -1,0 +1,31 @@
+package job
+
+import (
+	"github.com/dnephin/dobi/tasks/context"
+	"github.com/dnephin/dobi/tasks/image"
+)
+
+func (t *Task) runWithBuildAndCopy(ctx *context.ExecuteContext) error {
+	imageID, err := buildImageWithMounts(ctx)
+	if err != nil {
+		return err
+	}
+
+	name := containerName(ctx, t.name.Resource())
+	options := t.createOptions(ctx, name, imageID)
+	defer removeContainerWithLogging(t.logger(), ctx.Client, name)
+
+	if err := t.runContainer(ctx, options); err != nil {
+		return err
+	}
+	return copyFilesToHost(ctx, name)
+}
+
+func buildImageWithMounts(ctx *context.ExecuteContext) (string, error) {
+	imageName := image.GetImageName(ctx, ctx.Resources.Image(t.config.Use))
+	return "", nil
+}
+
+func copyFilesToHost(ctx *context.ExecuteContext, containerID string) error {
+	return nil
+}

--- a/tasks/job/build_test.go
+++ b/tasks/job/build_test.go
@@ -1,0 +1,87 @@
+package job
+
+import (
+	"github.com/dnephin/dobi/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetArtifactPath(t *testing.T) {
+	workingDir := "/work"
+	mounts := []config.MountConfig{
+		{
+			Bind: ".",
+			Path: "/go/src/github.com/dnephin/dobi",
+		},
+		{
+			Bind: "./dist/bin/",
+			Path: "/go/bin",
+		},
+	}
+
+	var testcases = []struct {
+		doc      string
+		glob     string
+		expected artifactPath
+	}{
+		{
+			doc:      "directory glob, exact match with mount",
+			glob:     "./dist/bin/",
+			expected: newArtifactPath("/work/dist/bin/", "/go/bin", "/work/dist/bin/"),
+		},
+	}
+	for _, testcase := range testcases {
+		actual, err := getArtifactPath(workingDir, testcase.glob, mounts)
+		if assert.NoError(t, err, testcase.doc) {
+			assert.Equal(t, testcase.expected, actual, testcase.doc)
+		}
+	}
+}
+
+func TestHasPathPrefix(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		path     string
+		prefix   string
+		expected bool
+	}{
+		{
+			doc:      "identical parts match",
+			path:     "/one/two/three",
+			prefix:   "/one/two/three",
+			expected: true,
+		},
+		{
+			doc:      "parts match with trailing slash",
+			path:     "/one/two/three/",
+			prefix:   "/one/two/three",
+			expected: true,
+		},
+		{
+			doc:      "parts match with trailing slash on prefix",
+			path:     "/one/two/three",
+			prefix:   "/one/two/three/",
+			expected: true,
+		},
+		{
+			doc:      "prefix match",
+			path:     "/one/two/three",
+			prefix:   "/one/two",
+			expected: true,
+		},
+		{
+			doc:    "item mismatch",
+			path:   "/one/two/three",
+			prefix: "/one/three/three",
+		},
+		{
+			doc:    "prefix longer mismatch",
+			path:   "/one/two/three",
+			prefix: "/one/two/three/four",
+		},
+	}
+	for _, testcase := range testcases {
+		actual := hasPathPrefix(testcase.path, testcase.prefix)
+		assert.Equal(t, testcase.expected, actual, testcase.doc)
+	}
+}

--- a/tasks/job/common.go
+++ b/tasks/job/common.go
@@ -9,14 +9,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// ContainerName returns the name of the container
-func ContainerName(ctx *context.ExecuteContext, name string) string {
+// containerName returns the name of the container
+func containerName(ctx *context.ExecuteContext, name string) string {
 	return fmt.Sprintf("%s-%s", ctx.Env.Unique(), name)
 }
 
-// RemoveContainer removes a container by ID, and logs a warning if the remove
+// removeContainer removes a container by ID, and logs a warning if the remove
 // fails.
-func RemoveContainer(
+func removeContainer(
 	logger *log.Entry,
 	client client.DockerClient,
 	containerID string,

--- a/tasks/job/remove.go
+++ b/tasks/job/remove.go
@@ -37,7 +37,7 @@ func (t *RemoveTask) Repr() string {
 func (t *RemoveTask) Run(ctx *context.ExecuteContext, _ bool) (bool, error) {
 	logger := logging.ForTask(t)
 
-	RemoveContainer(logger, ctx.Client, ContainerName(ctx, t.name.Resource())) // nolint: errcheck
+	removeContainer(logger, ctx.Client, containerName(ctx, t.name.Resource())) // nolint: errcheck
 
 	for _, path := range t.config.Artifact.Paths() {
 		if err := os.RemoveAll(path); err != nil {

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -186,7 +186,10 @@ func removeContainerWithLogging(
 	}
 }
 
-func (t *Task) runContainer(ctx *context.ExecuteContext, options docker.CreateContainerOptions) error {
+func (t *Task) runContainer(
+	ctx *context.ExecuteContext,
+	options docker.CreateContainerOptions,
+) error {
 	name := options.Name
 	container, err := ctx.Client.CreateContainer(options)
 	if err != nil {

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -169,7 +169,6 @@ func (t *Task) bindMounts(ctx *context.ExecuteContext) []string {
 }
 
 func (t *Task) runContainer(ctx *context.ExecuteContext) error {
-	interactive := t.config.Interactive
 	name := ContainerName(ctx, t.name.Resource())
 	container, err := ctx.Client.CreateContainer(t.createOptions(ctx, name))
 	if err != nil {
@@ -201,7 +200,7 @@ func (t *Task) runContainer(ctx *context.ExecuteContext) error {
 		return fmt.Errorf("failed attaching to container %q: %s", name, err)
 	}
 
-	if interactive {
+	if t.config.Interactive {
 		inFd, _ := term.GetFdInfo(os.Stdin)
 		state, err := term.SetRawTerminal(inFd)
 		if err != nil {

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -82,7 +82,12 @@ func (t *Task) Run(ctx *context.ExecuteContext, depsModified bool) (bool, error)
 	t.logger().Debug("is stale")
 
 	t.logger().Info("Start")
-	err := t.runContainer(ctx)
+	var err error
+	if ctx.Settings.BindMount {
+		err = t.runContainerWithBinds(ctx)
+	} else {
+		err = t.runWithBuildAndCopy(ctx)
+	}
 	if err != nil {
 		return false, err
 	}
@@ -160,30 +165,44 @@ func (t *Task) mountsLastModified(ctx *context.ExecuteContext) (time.Time, error
 	return fs.LastModified(mountPaths...)
 }
 
-func (t *Task) bindMounts(ctx *context.ExecuteContext) []string {
+func getBindMountsForHostConfig(ctx *context.ExecuteContext, mounts []string) []string {
 	binds := []string{}
-	ctx.Resources.EachMount(t.config.Mounts, func(name string, config *config.MountConfig) {
+	ctx.Resources.EachMount(mounts, func(name string, config *config.MountConfig) {
 		binds = append(binds, mount.AsBind(config, ctx.WorkingDir))
 	})
 	return binds
 }
 
-func (t *Task) runContainer(ctx *context.ExecuteContext) error {
-	name := ContainerName(ctx, t.name.Resource())
-	container, err := ctx.Client.CreateContainer(t.createOptions(ctx, name))
+func (t *Task) runContainerWithBinds(ctx *context.ExecuteContext) error {
+	name := containerName(ctx, t.name.Resource())
+	imageName := image.GetImageName(ctx, ctx.Resources.Image(t.config.Use))
+	options := t.createOptions(ctx, name, imageName)
+
+	defer removeContainerWithLogging(t.logger(), ctx.Client, name)
+	return t.runContainer(ctx, options)
+}
+
+func removeContainerWithLogging(
+	logger *log.Entry,
+	client client.DockerClient,
+	containerID string,
+) {
+	removed, err := removeContainer(logger, client, containerID)
+	if !removed && err == nil {
+		logger.WithFields(log.Fields{"container": containerID}).Warn(
+			"Container does not exist")
+	}
+}
+
+func (t *Task) runContainer(ctx *context.ExecuteContext, options docker.CreateContainerOptions) error {
+	name := options.Name
+	container, err := ctx.Client.CreateContainer(options)
 	if err != nil {
 		return fmt.Errorf("failed creating container %q: %s", name, err)
 	}
 
 	chanSig := t.forwardSignals(ctx.Client, container.ID)
 	defer signal.Stop(chanSig)
-	defer func() {
-		removed, err := RemoveContainer(t.logger(), ctx.Client, container.ID)
-		if !removed && err == nil {
-			t.logger().WithFields(log.Fields{"container": container.ID}).Warnf(
-				"Container does not exist")
-		}
-	}()
 
 	_, err = ctx.Client.AttachToContainerNonBlocking(docker.AttachToContainerOptions{
 		Container:    container.ID,
@@ -230,12 +249,11 @@ func (t *Task) output() io.Writer {
 func (t *Task) createOptions(
 	ctx *context.ExecuteContext,
 	name string,
+	imageName string,
 ) docker.CreateContainerOptions {
-	interactive := t.config.Interactive
-
-	imageName := image.GetImageName(ctx, ctx.Resources.Image(t.config.Use))
 	t.logger().Debugf("Image name %q", imageName)
 
+	interactive := t.config.Interactive
 	portBinds, exposedPorts := asPortBindings(t.config.Ports)
 	// TODO: only set Tty if running in a tty
 	opts := docker.CreateContainerOptions{
@@ -257,7 +275,7 @@ func (t *Task) createOptions(
 			ExposedPorts: exposedPorts,
 		},
 		HostConfig: &docker.HostConfig{
-			Binds:        t.bindMounts(ctx),
+			Binds:        getBindMountsForHostConfig(ctx, t.config.Mounts),
 			Privileged:   t.config.Privileged,
 			NetworkMode:  t.config.NetMode,
 			PortBindings: portBinds,

--- a/tasks/mount/mount.go
+++ b/tasks/mount/mount.go
@@ -56,10 +56,10 @@ func (t *createAction) run(ctx *context.ExecuteContext) (bool, error) {
 
 	var err error
 	switch {
-	case t.task.config.Name != "":
-		err = t.createNamed(ctx)
-	default:
+	case t.task.config.IsBind():
 		err = t.createBind(ctx)
+	default:
+		err = t.createNamed(ctx)
 	}
 	if err != nil {
 		return false, err

--- a/tasks/mount/mount_test.go
+++ b/tasks/mount/mount_test.go
@@ -42,7 +42,7 @@ func (s *CreateTaskSuite) SetupTest() {
 	s.action = &createAction{task: s.task}
 
 	s.ctx = context.NewExecuteContext(
-		&config.Config{WorkingDir: s.path}, nil, nil, false)
+		&config.Config{WorkingDir: s.path}, nil, nil, context.Settings{})
 }
 
 func (s *CreateTaskSuite) TearDownTest() {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -175,10 +175,11 @@ func hasModifiedDeps(ctx *context.ExecuteContext, deps []string) bool {
 
 // RunOptions are the options supported by Run
 type RunOptions struct {
-	Client client.DockerClient
-	Config *config.Config
-	Tasks  []string
-	Quiet  bool
+	Client    client.DockerClient
+	Config    *config.Config
+	Tasks     []string
+	Quiet     bool
+	BindMount bool
 }
 
 func getNames(options RunOptions) []string {
@@ -218,6 +219,6 @@ func Run(options RunOptions) error {
 		options.Config,
 		options.Client,
 		execEnv,
-		options.Quiet)
+		context.NewSettings(options.Quiet, options.BindMount))
 	return executeTasks(ctx, tasks)
 }


### PR DESCRIPTION
Fixes #88

Some environments dont work with bind mounts. This PR adds a flag to `dobi` to support job tasks without needing bind mounts. This is accomplished by building an image with an extra `COPY` layer for each bind mount, running the job using the new image, and then copying the artifacts out of the container when it's done.