### PR TITLE
Only set modified when an env var changes in value

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -260,6 +260,7 @@
   packages = [
     "assert",
     "assert/cmp",
+    "env",
     "fs",
     "internal/difflib",
     "internal/format",
@@ -272,6 +273,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9cab21cb853ea8d780dd545f3ef1d9c5e9261c279a901f40ea952183907e50f7"
+  inputs-digest = "7a5edc723a724c81b4879dbb691028f6f52b63347c6307f70d0f729bdcac4d35"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,16 +1,25 @@
 FROM    golang:1.10-alpine
 RUN     apk add -U git bash curl tree
 
-ARG     DEP=v0.4.1
-ARG     DEPURL=https://github.com/golang/dep/releases/download
-RUN     curl -sL -o /usr/bin/dep "${DEPURL}/${DEP}/dep-linux-amd64" && \
-        chmod +x /usr/bin/dep
-
-ARG     FILEWATCHER=v0.2.1
+ARG     FILEWATCHER_SHA=v0.3.0
 RUN     go get -d github.com/dnephin/filewatcher && \
         cd /go/src/github.com/dnephin/filewatcher && \
-        git checkout -q "$FILEWATCHER" && \
+        git checkout -q "$FILEWATCHER_SHA" && \
         go build -v -o /usr/bin/filewatcher . && \
+        rm -rf /go/src/* /go/pkg/* /go/bin/*
+
+ARG     DEP_TAG=v0.4.1
+RUN     go get -d github.com/golang/dep/cmd/dep && \
+        cd /go/src/github.com/golang/dep && \
+        git checkout -q "$DEP_TAG" && \
+        go build -v -o /usr/bin/dep ./cmd/dep && \
+        rm -rf /go/src/* /go/pkg/* /go/bin/*
+
+ARG     GOTESTSUM=v0.3.0
+RUN     go get -d gotest.tools/gotestsum && \
+        cd /go/src/gotest.tools/gotestsum && \
+        git checkout -q "$GOTESTSUM" && \
+        go build -v -o /usr/bin/gotestsum . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
 RUN     go get github.com/mitchellh/gox && \

--- a/script/watch
+++ b/script/watch
@@ -1,6 +1,5 @@
 #!/bin/bash
 exec filewatcher \
-    -e create -e write \
     -x 'dist' \
     -x 'dockerfiles' \
     -x 'docs' \
@@ -11,4 +10,4 @@ exec filewatcher \
     -x '**/*___jb_tmp___' \
     -x '**/*___jb_old___' \
     -- \
-    go test -v -timeout 10s './${dir}'
+    gotestsum -- -test.timeout 10s

--- a/tasks/env/env_test.go
+++ b/tasks/env/env_test.go
@@ -1,0 +1,63 @@
+package env
+
+import (
+	"testing"
+
+	"os"
+
+	"github.com/dnephin/dobi/config"
+	"github.com/dnephin/dobi/tasks/task"
+	"gotest.tools/assert"
+	"gotest.tools/env"
+)
+
+func TestTask_Run(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		expected bool
+		vars     map[string]string
+	}{
+		{
+			doc: "set from variables",
+			vars: map[string]string{
+				"VAR_ONE": "override",
+				"VAR_TWO": "new",
+			},
+			expected: true,
+		},
+		{
+			doc: "no modifications",
+			vars: map[string]string{
+				"VAR_ONE": "preset",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.doc, func(t *testing.T) {
+			defer env.PatchAll(t, map[string]string{
+				"VAR_ONE": "preset",
+			})()
+
+			envTask := newTask(task.NewName("foo", ""), &config.EnvConfig{
+				Variables: toSlice(tc.vars),
+			})
+
+			modified, err := envTask.Run(nil, false)
+			assert.NilError(t, err)
+			assert.Equal(t, modified, tc.expected)
+
+			for k, v := range tc.vars {
+				assert.Equal(t, os.Getenv(k), v)
+			}
+		})
+	}
+}
+
+func toSlice(m map[string]string) []string {
+	p := []string{}
+	for k, v := range m {
+		p = append(p, k+"="+v)
+	}
+	return p
+}

--- a/tasks/job/capture.go
+++ b/tasks/job/capture.go
@@ -46,14 +46,17 @@ func (t *captureTask) Repr() string {
 }
 
 // Run the job to capture the output in a variable
-func (t *captureTask) Run(ctx *context.ExecuteContext, _ bool) (bool, error) {
-	// Always pass depsModified as true so that the task runs and is never cached
-	modified, err := t.runTask.Run(ctx, true)
+func (t *captureTask) Run(ctx *context.ExecuteContext, depsModified bool) (bool, error) {
+	modified, err := t.runTask.Run(ctx, depsModified)
 	if err != nil {
 		return modified, err
 	}
 
 	out := strings.TrimSpace(t.buffer.String())
+	if current, ok := os.LookupEnv(t.variable); ok && current == out {
+		return false, nil
+	}
+
 	logging.ForTask(t).Debug("Setting %q to: %s", t.variable, out)
 	return true, os.Setenv(t.variable, out)
 }

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -75,8 +75,6 @@ func collect(options RunOptions, state *collectionState) (*TaskCollection, error
 			return nil, err
 		}
 
-		// TODO: cache tasksConfigs until an env resource invalidates them
-
 		if state.taskStack.Contains(taskConfig.Name()) {
 			return nil, fmt.Errorf(
 				"Invalid dependency cycle: %s", strings.Join(state.taskStack.Names(), ", "))


### PR DESCRIPTION
Fixes #74 

`env` and `job.capture` both set environment variables. This PR fixes them to only return modified if the value of the env var changes.