### PR TITLE
Add signal handler for handling a TTY resize

### DIFF
--- a/tasks/client/iface.go
+++ b/tasks/client/iface.go
@@ -25,4 +25,5 @@ type DockerClient interface {
 
 	CreateVolume(opts docker.CreateVolumeOptions) (*docker.Volume, error)
 	RemoveVolume(name string) error
+	ResizeContainerTTY(id string, height, width int) error
 }

--- a/tasks/client/mock_iface.go
+++ b/tasks/client/mock_iface.go
@@ -216,3 +216,15 @@ func (_m *MockDockerClient) RemoveVolume(name string) error {
 func (_mr *MockDockerClientMockRecorder) RemoveVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RemoveVolume", reflect.TypeOf((*MockDockerClient)(nil).RemoveVolume), arg0)
 }
+
+// ResizeContainerTTY mocks base method
+func (_m *MockDockerClient) ResizeContainerTTY(id string, height int, width int) error {
+	ret := _m.ctrl.Call(_m, "ResizeContainerTTY", id, height, width)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResizeContainerTTY indicates an expected call of ResizeContainerTTY
+func (_mr *MockDockerClientMockRecorder) ResizeContainerTTY(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "ResizeContainerTTY", reflect.TypeOf((*MockDockerClient)(nil).ResizeContainerTTY), arg0, arg1, arg2)
+}

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -231,6 +231,10 @@ func (t *Task) runContainer(
 		return fmt.Errorf("failed starting container %q: %s", name, err)
 	}
 
+	// Send a SIGWINCH signal to make sure terminals to have the correct
+	// window dimensions
+	chanSig <- syscall.SIGWINCH
+
 	return t.wait(ctx.Client, container.ID)
 }
 
@@ -350,6 +354,35 @@ func (t *Task) wait(client client.DockerClient, containerID string) error {
 	return nil
 }
 
+func (t *Task) winSizeChangeSignalHandler(client client.DockerClient,
+	containerID string, sig syscall.Signal) {
+
+	winsize, err := term.GetWinsize(os.Stdin.Fd())
+	if err != nil {
+		t.logger().WithFields(log.Fields{"signal": sig}).
+			Errorf("Failed to get host's TTY window size")
+		return
+	}
+
+	err = client.ResizeContainerTTY(containerID, int(winsize.Height), int(winsize.Width))
+	if err != nil {
+		t.logger().WithFields(log.Fields{"signal": sig}).
+			Errorf("Failed to set container's TTY window size")
+	}
+}
+
+func (t *Task) killSignalHandler(client client.DockerClient,
+	containerID string, sig syscall.Signal) {
+
+	if err := client.KillContainer(docker.KillContainerOptions{
+		ID:     containerID,
+		Signal: docker.Signal(sig),
+	}); err != nil {
+		t.logger().WithFields(log.Fields{"signal": sig}).Warnf(
+			"Failed to send signal: %s", err)
+	}
+}
+
 func (t *Task) forwardSignals(
 	client client.DockerClient,
 	containerID string,
@@ -357,30 +390,26 @@ func (t *Task) forwardSignals(
 	chanSig := make(chan os.Signal, 128)
 
 	// TODO: not all of these exist on windows?
-	signal.Notify(chanSig, syscall.SIGINT, syscall.SIGTERM)
-
-	kill := func(sig os.Signal) {
-		t.logger().WithFields(log.Fields{"signal": sig}).Debug("received")
-
-		intSig, ok := sig.(syscall.Signal)
-		if !ok {
-			t.logger().WithFields(log.Fields{"signal": sig}).Warnf(
-				"Failed to convert signal from %T", sig)
-			return
-		}
-
-		if err := client.KillContainer(docker.KillContainerOptions{
-			ID:     containerID,
-			Signal: docker.Signal(intSig),
-		}); err != nil {
-			t.logger().WithFields(log.Fields{"signal": sig}).Warnf(
-				"Failed to send signal: %s", err)
-		}
-	}
+	signal.Notify(chanSig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH)
 
 	go func() {
 		for sig := range chanSig {
-			kill(sig)
+			intSig, ok := sig.(syscall.Signal)
+			if !ok {
+				t.logger().WithFields(log.Fields{"signal": sig}).Warnf(
+					"Failed to convert signal from %T", sig)
+				return
+			}
+
+			t.logger().WithFields(log.Fields{"signal": sig}).Debug("received")
+
+			if intSig == syscall.SIGWINCH {
+				t.winSizeChangeSignalHandler(client, containerID, intSig)
+			}
+
+			if intSig == syscall.SIGINT || intSig == syscall.SIGTERM {
+				t.killSignalHandler(client, containerID, intSig)
+			}
 		}
 	}()
 	return chanSig


### PR DESCRIPTION
This fixes an issue whereby the terminal doesn't get given a size by dobi and therefore it can be problematic to type long commands in an interactive terminal.

Reproduction Example:

1. Create a Dockerfile with the following contents:
`FROM debian:latest`
2. Create a dobi.yaml with the following contents:
```
image=debian:
    image: debian
    dockerfile: Dockerfile.debian
job=debian-job:
    use: debian
    interactive: true
```
3. Run `dobi debian-job`
4. Run `stty size`

You should end up with the following result before this fix:
```
dobi debian-job
[WARN] meta.project is not set. Using default "Downloads".
[image:build debian] debian is fresh
[job: debian-job] Start
root@e5fc2dff86db:/# stty size
0 0
root@e5fc2dff86db:/# 
```

5. Hold down a key to repeat typing for a while and you will see that the line wraps back to the beginning of the same line (doesn't perform a carriage return properly) and you will end up with the terminal overwriting the current line with the newly typed data. You can see in the example output below that the root@0e part of the terminal prompt has been overwritten with 'a':
```
dobi debian-job
[WARN] meta.project is not set. Using default "Downloads".
[image:build debian] debian is fresh
[job: debian-job] Start
root@0e83d5bbc229:/# 
aaaaaae83d5bbc229:/# aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

After the fix is applied (obviously the stty size result will depend upon the actual terminal size):
```
github.com/dnephin/dobi/dist/bin/dobi debian-job
[WARN] meta.project is not set. Using default "Downloads".
[image:build debian] debian is fresh
[job: debian-job] Start
root@854a6c77cf0d:/# stty size
65 273
root@854a6c77cf0d:/# 
```


