### PR TITLE
ignore .dobi directory when computing build context modified time

### DIFF
--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -10,6 +10,7 @@ import (
 // directories. The files in each directory are checked for their last modified
 // time.
 // TODO: use go routines to speed this up
+// nolint: gocyclo
 func LastModified(fileOrDir ...string) (time.Time, error) {
 	var latest time.Time
 
@@ -17,6 +18,9 @@ func LastModified(fileOrDir ...string) (time.Time, error) {
 	walker := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		if info.IsDir() && info.Name() == ".dobi" {
+			return filepath.SkipDir
 		}
 		if info.ModTime().After(latest) {
 			latest = info.ModTime()


### PR DESCRIPTION
If we want to use dobi to build our repo, it makes sense to put the dobi.yaml in the same repo, but unfortunately the docker context is in the root of the repo. dobi creates a .dobi directory in the same dir as the dobi.yaml file to track various things, which triggers rebuilds every time when files change under .dobi.

Let's just ignore .dobi and everything under it when computing the docker build context age.