### PR TITLE
feat(image): push action authenticates against each tag

### DIFF
--- a/config/image.go
+++ b/config/image.go
@@ -15,7 +15,7 @@ import (
 // ImageConfig An **image** resource provides actions for working with a Docker
 // image. If an image is buildable it is considered up-to-date if all files in
 // the build context have a modified time older than the created time of the
-// image. If using inline Dockerfile, the **dobi.yaml** file will be considered 
+// image. If using inline Dockerfile, the **dobi.yaml** file will be considered
 // as a part of the build context.
 // name: image
 // example: An image with build args:

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,7 +1,7 @@
-FROM    golang:1.10-alpine
+FROM    golang:1.13-alpine
 RUN     apk add -U git bash curl tree
 
-ARG     FILEWATCHER_SHA=v0.3.0
+ARG     FILEWATCHER_SHA=v0.3.2
 RUN     go get -d github.com/dnephin/filewatcher && \
         cd /go/src/github.com/dnephin/filewatcher && \
         git checkout -q "$FILEWATCHER_SHA" && \
@@ -15,7 +15,7 @@ RUN     go get -d github.com/golang/dep/cmd/dep && \
         go build -v -o /usr/bin/dep ./cmd/dep && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ARG     GOTESTSUM=v0.3.0
+ARG     GOTESTSUM=v0.4.0
 RUN     go get -d gotest.tools/gotestsum && \
         cd /go/src/gotest.tools/gotestsum && \
         git checkout -q "$GOTESTSUM" && \

--- a/dockerfiles/Dockerfile.docs
+++ b/dockerfiles/Dockerfile.docs
@@ -1,4 +1,4 @@
-FROM    alpine:3.6
+FROM    alpine:3.10
 
 RUN     apk -U add \
             python \

--- a/tasks/image/push.go
+++ b/tasks/image/push.go
@@ -11,7 +11,7 @@ import (
 // RunPush pushes an image to the registry
 func RunPush(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	pushTag := func(tag string) error {
-		return pushImage(ctx, t, tag)
+		return pushImage(ctx, tag)
 	}
 	if err := t.ForEachTag(ctx, pushTag); err != nil {
 		return false, err
@@ -20,7 +20,7 @@ func RunPush(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	return true, nil
 }
 
-func pushImage(ctx *context.ExecuteContext, t *Task, tag string) error {
+func pushImage(ctx *context.ExecuteContext, tag string) error {
 	repo, err := parseAuthRepo(tag)
 	if err != nil {
 		return err

--- a/tasks/image/push.go
+++ b/tasks/image/push.go
@@ -21,7 +21,7 @@ func RunPush(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 }
 
 func pushImage(ctx *context.ExecuteContext, t *Task, tag string) error {
-	repo, err := parseAuthRepo(t.config.Image)
+	repo, err := parseAuthRepo(tag)
 	if err != nil {
 		return err
 	}

--- a/tasks/job/build.go
+++ b/tasks/job/build.go
@@ -328,7 +328,9 @@ func createFromTar(tarReader io.Reader, header *tar.Header, path artifactPath) e
 		return os.Symlink(header.Linkname, hostPath)
 
 	default:
-		logging.Log.Warnf("Unhandled file type from archive %s: %s", header.Typeflag, header.Name)
+		logging.Log.Warnf("Unhandled file type from archive %s: %s",
+			string(header.Typeflag),
+			header.Name)
 	}
 
 	return nil

--- a/tasks/job/capture.go
+++ b/tasks/job/capture.go
@@ -57,6 +57,6 @@ func (t *captureTask) Run(ctx *context.ExecuteContext, depsModified bool) (bool,
 		return false, nil
 	}
 
-	logging.ForTask(t).Debug("Setting %q to: %s", t.variable, out)
+	logging.ForTask(t).Debugf("Setting %q to: %s", t.variable, out)
 	return true, os.Setenv(t.variable, out)
 }


### PR DESCRIPTION
The tag argument is expanded with t.config.Image if it only contains
the part after `:`.  If it is the entire image name this is used
instead.  In both cases the argument contains the registry which we
can extract and auth against.

fixes #170 