### PR TITLE
Added 'pull: local'

### DIFF
--- a/config/image.go
+++ b/config/image.go
@@ -55,6 +55,7 @@ type ImageConfig struct {
 	// Pull Pull an image instead of building it. The value may be one of:
 	// * ``once`` - only pull if the image:tag does not exist
 	// * ``always`` - always pull the image
+	// * ``local`` - don't pull or build the image. Use one that is already present locally
 	// * ``<duration>`` - pull if the image hasn't been pulled in at least
 	//   ``duration``. The format of duration is a number followed by a single
 	//   character time unit (ex: ``40s``, ``2h``, ``30min``)
@@ -196,6 +197,8 @@ func (p *pull) TransformConfig(raw reflect.Value) error {
 		switch value {
 		case "once":
 			p.action = pullOnce
+		case "local":
+			p.action = pullLocal
 		case "always":
 			p.action = pullAlways
 		default:
@@ -224,6 +227,10 @@ func (p *pull) IsSet() bool {
 
 func pullAlways(_ *time.Time) bool {
 	return true
+}
+
+func pullLocal(_ *time.Time) bool {
+	return false
 }
 
 func pullOnce(lastPull *time.Time) bool {

--- a/config/image.go
+++ b/config/image.go
@@ -55,7 +55,7 @@ type ImageConfig struct {
 	// Pull Pull an image instead of building it. The value may be one of:
 	// * ``once`` - only pull if the image:tag does not exist
 	// * ``always`` - always pull the image
-	// * ``local`` - don't pull or build the image. Use one that is already present locally
+	// * ``never`` - don't pull or build the image. Use one that is already present locally
 	// * ``<duration>`` - pull if the image hasn't been pulled in at least
 	//   ``duration``. The format of duration is a number followed by a single
 	//   character time unit (ex: ``40s``, ``2h``, ``30min``)
@@ -197,8 +197,8 @@ func (p *pull) TransformConfig(raw reflect.Value) error {
 		switch value {
 		case "once":
 			p.action = pullOnce
-		case "local":
-			p.action = pullLocal
+		case "never":
+			p.action = pullNever
 		case "always":
 			p.action = pullAlways
 		default:
@@ -229,7 +229,7 @@ func pullAlways(_ *time.Time) bool {
 	return true
 }
 
-func pullLocal(_ *time.Time) bool {
+func pullNever(_ *time.Time) bool {
 	return false
 }
 

--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -13,8 +13,22 @@ import (
 func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	record, err := getImageRecord(recordPath(ctx, t.config))
 	if err != nil {
-		t.logger().Warnf("Failed to get image record: %s", err)
+		if os.IsNotExist(err) {
+			t.logger().Info("Creating image record")
+			image, err := GetImage(ctx, t.config)
+			if err != nil {
+				return false, err
+			}
+			record := imageModifiedRecord{ImageID: image.ID}
+			updateImageRecord(recordPath(ctx, t.config), record)
+			if err != nil {
+				return false, err
+			}
+		} else {
+			t.logger().Warnf("Failed to get image record: %s", err)
+		}
 	}
+
 	if !t.config.Pull.Required(record.LastPull) {
 		t.logger().Debugf("Pull not required")
 		return false, nil

--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -12,13 +12,12 @@ import (
 // RunPull builds or pulls an image if it is out of date
 func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	record, err := getImageRecord(recordPath(ctx, t.config))
-	if err != nil {
-		t.logger().Warnf("Failed to get image record: %s", err)
-	}
-
-	if !t.config.Pull.Required(record.LastPull) {
+	switch {
+	case !t.config.Pull.Required(record.LastPull):
 		t.logger().Debugf("Pull not required")
 		return false, nil
+	case err != nil:
+		t.logger().Warnf("Failed to get image record: %s", err)
 	}
 
 	pullTag := func(tag string) error {

--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -13,20 +13,7 @@ import (
 func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	record, err := getImageRecord(recordPath(ctx, t.config))
 	if err != nil {
-		if os.IsNotExist(err) {
-			t.logger().Info("Creating image record")
-			image, err := GetImage(ctx, t.config)
-			if err != nil {
-				return false, err
-			}
-			record := imageModifiedRecord{ImageID: image.ID}
-			updateImageRecord(recordPath(ctx, t.config), record)
-			if err != nil {
-				return false, err
-			}
-		} else {
-			t.logger().Warnf("Failed to get image record: %s", err)
-		}
+		t.logger().Warnf("Failed to get image record: %s", err)
 	}
 
 	if !t.config.Pull.Required(record.LastPull) {


### PR DESCRIPTION
Uses an already present docker image without pulling or building it. This can be useful if one has an docker image that shall get used without building it (e.g .image that was made with `docker commit`) or pulling it (e.g. no docker registry is present).

Example usage:
```
image=runtime:
  image: ubuntu
  tags: ["latest"]
  pull: local
  annotations:
    description: "image"

job=run:
  use: runtime
  command: ls
  annotations:
    description: "run"
```

In the above example dobi will use the local instance of ubuntu:latest and does not care pulling or building it.