### PR TITLE
Ignore .git directory when determining if context has changed

### DIFF
--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -14,13 +14,22 @@ import (
 func LastModified(fileOrDir ...string) (time.Time, error) {
 	var latest time.Time
 
+	ignoredDirectories := []string{
+		".dobi",
+		".git",
+	}
+
 	// TODO: does this error contain enough context?
 	walker := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() && info.Name() == ".dobi" {
-			return filepath.SkipDir
+		if info.IsDir() {
+			for _, dir := range ignoredDirectories {
+				if dir == info.Name() {
+					return filepath.SkipDir
+				}
+			}
 		}
 		if info.ModTime().After(latest) {
 			latest = info.ModTime()


### PR DESCRIPTION
There are other directories in the root of a project that we'd want to ignore other than .dobi. Eventually it might make sense to make this configurable via a meta parameter. 

Closes #179. 