### PR TITLE
Leverage contents of dockerignore to determine whether image is stale

### DIFF
--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -69,7 +69,17 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 	if t.config.Steps != "" && ctx.ConfigFile != "" {
 		paths = append(paths, ctx.ConfigFile)
 	}
-	mtime, err := fs.LastModified(paths...)
+
+	excludes := []string{}
+	dockerignoreEntries, err := build.ReadDockerignore(t.config.Context)
+	if err == nil {
+		excludes = dockerignoreEntries
+	} else {
+		t.logger().Warnf("Failed to read .dockerignore file.")
+	}
+	excludes = append(excludes, ".dobi")
+
+	mtime, err := fs.LastModified(excludes, paths...)
 	if err != nil {
 		t.logger().Warnf("Failed to get last modified time of context.")
 		return true, err

--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -70,11 +70,8 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 		paths = append(paths, ctx.ConfigFile)
 	}
 
-	excludes := []string{}
-	dockerignoreEntries, err := build.ReadDockerignore(t.config.Context)
-	if err == nil {
-		excludes = dockerignoreEntries
-	} else {
+	excludes, err := build.ReadDockerignore(t.config.Context)
+	if err != nil {
 		t.logger().Warnf("Failed to read .dockerignore file.")
 	}
 	excludes = append(excludes, ".dobi")

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -113,7 +113,7 @@ func (t *Task) isStale(ctx *context.ExecuteContext) (bool, error) {
 	}
 
 	if len(t.config.Sources.Paths()) != 0 {
-		sourcesLastModified, err := fs.LastModified(t.config.Sources.Paths()...)
+		sourcesLastModified, err := fs.LastModified([]string{}, t.config.Sources.Paths()...)
 		if err != nil {
 			return true, err
 		}
@@ -153,7 +153,7 @@ func (t *Task) artifactLastModified() (time.Time, error) {
 	if len(paths) == 0 {
 		return time.Time{}, nil
 	}
-	return fs.LastModified(paths...)
+	return fs.LastModified([]string{}, paths...)
 }
 
 // TODO: support a .mountignore file used to ignore mtime of files
@@ -162,7 +162,7 @@ func (t *Task) mountsLastModified(ctx *context.ExecuteContext) (time.Time, error
 	ctx.Resources.EachMount(t.config.Mounts, func(name string, mount *config.MountConfig) {
 		mountPaths = append(mountPaths, mount.Bind)
 	})
-	return fs.LastModified(mountPaths...)
+	return fs.LastModified([]string{}, mountPaths...)
 }
 
 func (t *Task) runContainerWithBinds(ctx *context.ExecuteContext) error {

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -113,7 +113,7 @@ func (t *Task) isStale(ctx *context.ExecuteContext) (bool, error) {
 	}
 
 	if len(t.config.Sources.Paths()) != 0 {
-		sourcesLastModified, err := fs.LastModified([]string{}, t.config.Sources.Paths()...)
+		sourcesLastModified, err := fs.LastModified(nil, t.config.Sources.Paths()...)
 		if err != nil {
 			return true, err
 		}
@@ -153,7 +153,7 @@ func (t *Task) artifactLastModified() (time.Time, error) {
 	if len(paths) == 0 {
 		return time.Time{}, nil
 	}
-	return fs.LastModified([]string{}, paths...)
+	return fs.LastModified(nil, paths...)
 }
 
 // TODO: support a .mountignore file used to ignore mtime of files
@@ -162,7 +162,7 @@ func (t *Task) mountsLastModified(ctx *context.ExecuteContext) (time.Time, error
 	ctx.Resources.EachMount(t.config.Mounts, func(name string, mount *config.MountConfig) {
 		mountPaths = append(mountPaths, mount.Bind)
 	})
-	return fs.LastModified([]string{}, mountPaths...)
+	return fs.LastModified(nil, mountPaths...)
 }
 
 func (t *Task) runContainerWithBinds(ctx *context.ExecuteContext) error {

--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -11,16 +11,22 @@ import (
 // time.
 // TODO: use go routines to speed this up
 // nolint: gocyclo
-func LastModified(fileOrDir ...string) (time.Time, error) {
+func LastModified(excludes []string, fileOrDir ...string) (time.Time, error) {
 	var latest time.Time
+	var excludedFileOrDir string
 
 	// TODO: does this error contain enough context?
 	walker := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() && info.Name() == ".dobi" {
-			return filepath.SkipDir
+		for _, excludedFileOrDir = range excludes {
+			if excludedFileOrDir == info.Name() {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
 		}
 		if info.ModTime().After(latest) {
 			latest = info.ModTime()
@@ -35,6 +41,11 @@ func LastModified(fileOrDir ...string) (time.Time, error) {
 		}
 		switch info.IsDir() {
 		case false:
+			for _, excludedFileOrDir = range excludes {
+				if excludedFileOrDir == info.Name() {
+					continue
+				}
+			}
 			if info.ModTime().After(latest) {
 				latest = info.ModTime()
 				continue

--- a/utils/fs/directory_test.go
+++ b/utils/fs/directory_test.go
@@ -21,7 +21,7 @@ func TestLastModified(t *testing.T) {
 		mtime := time.Now().AddDate(0, 0, index+10)
 		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), mtime)))
 
-		actual, err := LastModified(tmpdir.Path())
+		actual, err := LastModified([]string{}, tmpdir.Path())
 		assert.NilError(t, err)
 		assert.Equal(t, actual, mtime)
 	}

--- a/utils/fs/directory_test.go
+++ b/utils/fs/directory_test.go
@@ -21,7 +21,7 @@ func TestLastModified(t *testing.T) {
 		mtime := time.Now().AddDate(0, 0, index+10)
 		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), mtime)))
 
-		actual, err := LastModified([]string{}, tmpdir.Path())
+		actual, err := LastModified(nil, tmpdir.Path())
 		assert.NilError(t, err)
 		assert.Equal(t, actual, mtime)
 	}


### PR DESCRIPTION
Read the contents of the dockerignore file to determine whether or not an image is stale.

Closes #179

Signed-off-by: Tom Duffield <tom@chef.io>