### PR TITLE
Use file libraries to properly filter excludes

### DIFF
--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -76,7 +76,11 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 	}
 	excludes = append(excludes, ".dobi")
 
-	mtime, err := fs.LastModified(excludes, paths...)
+	mtime, err := fs.LastModified(&fs.LastModifiedSearch{
+		Root:     t.config.Context,
+		Excludes: excludes,
+		Paths:    paths,
+	})
 	if err != nil {
 		t.logger().Warnf("Failed to get last modified time of context.")
 		return true, err

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -113,7 +113,9 @@ func (t *Task) isStale(ctx *context.ExecuteContext) (bool, error) {
 	}
 
 	if len(t.config.Sources.Paths()) != 0 {
-		sourcesLastModified, err := fs.LastModified(nil, t.config.Sources.Paths()...)
+		sourcesLastModified, err := fs.LastModified(&fs.LastModifiedSearch{
+			Paths: t.config.Sources.Paths(),
+		})
 		if err != nil {
 			return true, err
 		}
@@ -153,7 +155,7 @@ func (t *Task) artifactLastModified() (time.Time, error) {
 	if len(paths) == 0 {
 		return time.Time{}, nil
 	}
-	return fs.LastModified(nil, paths...)
+	return fs.LastModified(&fs.LastModifiedSearch{Paths: paths})
 }
 
 // TODO: support a .mountignore file used to ignore mtime of files
@@ -162,7 +164,7 @@ func (t *Task) mountsLastModified(ctx *context.ExecuteContext) (time.Time, error
 	ctx.Resources.EachMount(t.config.Mounts, func(name string, mount *config.MountConfig) {
 		mountPaths = append(mountPaths, mount.Bind)
 	})
-	return fs.LastModified(nil, mountPaths...)
+	return fs.LastModified(&fs.LastModifiedSearch{Paths: mountPaths})
 }
 
 func (t *Task) runContainerWithBinds(ctx *context.ExecuteContext) error {

--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -1,32 +1,60 @@
 package fs
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/docker/docker/pkg/fileutils"
 )
+
+// LastModifiedSearch provides the means by which to specify your search parameters when
+// finding the last modified file.
+type LastModifiedSearch struct {
+	Root     string
+	Excludes []string
+	Paths    []string
+}
 
 // LastModified returns the latest modified time for all the files and
 // directories. The files in each directory are checked for their last modified
 // time.
 // TODO: use go routines to speed this up
 // nolint: gocyclo
-func LastModified(excludes []string, fileOrDir ...string) (time.Time, error) {
+func LastModified(search *LastModifiedSearch) (time.Time, error) {
 	var latest time.Time
-	var excludedFileOrDir string
+	var rootPath string
+	var err error
 
-	// TODO: does this error contain enough context?
-	walker := func(path string, info os.FileInfo, err error) error {
+	rootPath = search.Root
+	if rootPath == "" {
+		if rootPath, err = os.Getwd(); err != nil {
+			return time.Time{}, err
+		}
+	}
+
+	pm, err := fileutils.NewPatternMatcher(search.Excludes)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	walker := func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsPermission(err) {
+				return fmt.Errorf("can't stat '%s'", filePath)
+			}
 			return err
 		}
-		for _, excludedFileOrDir = range excludes {
-			if excludedFileOrDir == info.Name() {
-				if info.IsDir() {
-					return filepath.SkipDir
-				}
-				return nil
+		if relFilePath, err := filepath.Rel(rootPath, filePath); err != nil {
+			return err
+		} else if skip, err := filepathMatches(pm, relFilePath); err != nil {
+			return err
+		} else if skip {
+			if info.IsDir() {
+				return filepath.SkipDir
 			}
+			return nil
 		}
 		if info.ModTime().After(latest) {
 			latest = info.ModTime()
@@ -34,27 +62,38 @@ func LastModified(excludes []string, fileOrDir ...string) (time.Time, error) {
 		return nil
 	}
 
-	for _, file := range fileOrDir {
-		info, err := os.Stat(file)
+	for _, path := range search.Paths {
+		info, err := os.Stat(path)
 		if err != nil {
 			return latest, err
 		}
 		switch info.IsDir() {
 		case false:
-			for _, excludedFileOrDir = range excludes {
-				if excludedFileOrDir == info.Name() {
-					continue
-				}
+			if relPath, err := filepath.Rel(rootPath, path); err != nil {
+				return time.Time{}, err
+			} else if skip, err := filepathMatches(pm, relPath); err != nil {
+				return time.Time{}, err
+			} else if skip {
+				continue
 			}
 			if info.ModTime().After(latest) {
 				latest = info.ModTime()
 				continue
 			}
 		default:
-			if err := filepath.Walk(file, walker); err != nil {
+			if err := filepath.Walk(path, walker); err != nil {
 				return latest, err
 			}
 		}
 	}
 	return latest, nil
+}
+
+func filepathMatches(matcher *fileutils.PatternMatcher, file string) (bool, error) {
+	file = filepath.Clean(file)
+	if file == "." {
+		// Don't let them exclude everything, kind of silly.
+		return false, nil
+	}
+	return matcher.Matches(file)
 }

--- a/utils/fs/directory_test.go
+++ b/utils/fs/directory_test.go
@@ -21,10 +21,62 @@ func TestLastModified(t *testing.T) {
 		mtime := time.Now().AddDate(0, 0, index+10)
 		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), mtime)))
 
-		actual, err := LastModified(nil, tmpdir.Path())
+		actual, err := LastModified(&LastModifiedSearch{
+			Root:  tmpdir.Path(),
+			Paths: []string{tmpdir.Path()},
+		})
 		assert.NilError(t, err)
 		assert.Equal(t, actual, mtime)
 	}
+}
+
+func TestLastModifiedExcludesFile(t *testing.T) {
+	tmpdir := fs.NewDir(t, "test-directory-last-modified-excludes-file",
+		fs.WithDir("a"),
+		fs.WithDir("b",
+			fs.WithDir("c")))
+	defer tmpdir.Remove()
+
+	for index, dir := range []string{"a", "b", "b/c"} {
+		mtime := time.Now().AddDate(0, 0, index+10)
+		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), mtime)))
+
+		excludedFile := tmpdir.Join(dir, "excluded-file")
+		excludedMtime := time.Now().AddDate(0, 0, index+20)
+		assert.Assert(t, cmp.Nil(touch(excludedFile, excludedMtime)))
+
+		actual, err := LastModified(&LastModifiedSearch{
+			Root:     tmpdir.Path(),
+			Excludes: []string{"**/**/excluded-file"},
+			Paths:    []string{tmpdir.Path()},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, actual, mtime)
+	}
+}
+
+func TestLastModifiedExcludesFolder(t *testing.T) {
+	tmpdir := fs.NewDir(t, "test-directory-last-modified-excludes-folder",
+		fs.WithDir("a"),
+		fs.WithDir("b",
+			fs.WithDir("c")))
+	defer tmpdir.Remove()
+
+	mtime := time.Now().AddDate(0, 0, 0)
+	assert.Assert(t, cmp.Nil(touch(tmpdir.Join("a", "file"), mtime)))
+
+	for index, dir := range []string{"b", "b/c"} {
+		ignoredMtime := time.Now().AddDate(0, 0, index+10)
+		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), ignoredMtime)))
+	}
+
+	actual, err := LastModified(&LastModifiedSearch{
+		Excludes: []string{"b/"},
+		Paths:    []string{tmpdir.Path()},
+		Root:     tmpdir.Path(),
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, actual, mtime)
 }
 
 func touch(name string, mtime time.Time) error {


### PR DESCRIPTION
After adding testing, we discovered that the current method of filtering
only works if you're filtering top-level files or directories, which
satisfied the use case of skippiing the '.git' directory.

This add testing, shifts to passing search parameters as a struct, and
uses proper pattern matching to evaluate the dockerignore file based
on the Docker documentation.

Signed-off-by: Tom Duffield <tom@chef.io>