### PR TITLE
Write imageid to .dobi dir on pull action

### DIFF
--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -27,7 +27,12 @@ func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 		return false, err
 	}
 
-	record = imageModifiedRecord{LastPull: now()}
+	image, err := GetImage(ctx, t.config)
+	if err != nil {
+		return false, err
+	}
+	record = imageModifiedRecord{LastPull: now(), ImageID: image.ID}
+
 	if err := updateImageRecord(recordPath(ctx, t.config), record); err != nil {
 		t.logger().Warnf("Failed to update image record: %s", err)
 	}


### PR DESCRIPTION
On a pull action, dobi wasn't filling in the imageid field in the .dobi directory, causing a later build action to fail to use the cached version on the check:

if image.ID != record.ImageID || record.Info.ModTime().Before(mtime) {
	t.logger().Debug("Image record older than context")
	return true, nil
}
This change fixes it so dobi writes the imageid on pulls.