### PR TITLE
List by groups

### DIFF
--- a/config/resource.go
+++ b/config/resource.go
@@ -64,7 +64,10 @@ type AnnotationFields struct {
 	// Description Description of the resource. Adding a description to a
 	// resource makes it visible from ``dobi list``.
 	Description string
-	// Annotation group
+	// Group Group defines whether the resource can be listed by group.
+	// All resources sharing the same group are listed together.
+	// Don't set this value if the resource shall be not grouped.
+	// The grouped view is visible from ``dobi list -g``.
 	Group string
 	// Tags
 	Tags []string

--- a/config/resource.go
+++ b/config/resource.go
@@ -36,6 +36,9 @@ func (a *Annotations) Describe() string {
 
 // Group returns the group the resource belongs to
 func (a *Annotations) Group() string {
+	if a.Annotations.Group == "" {
+		return "none"
+	}
 	return a.Annotations.Group
 }
 

--- a/config/resource.go
+++ b/config/resource.go
@@ -12,6 +12,7 @@ type Resource interface {
 	Validate(pth.Path, *Config) *pth.Error
 	Resolve(Resolver) (Resource, error)
 	Describe() string
+	Group() string
 	CategoryTags() []string
 	String() string
 }
@@ -31,6 +32,11 @@ func (a *Annotations) Describe() string {
 	}
 	// fall back to old deprecated field
 	return a.Description
+}
+
+// Group returns the group the resource belongs to
+func (a *Annotations) Group() string {
+	return a.Annotations.Group
 }
 
 // CategoryTags tags returns the list of tags
@@ -55,6 +61,8 @@ type AnnotationFields struct {
 	// Description Description of the resource. Adding a description to a
 	// resource makes it visible from ``dobi list``.
 	Description string
+	// Annotation group
+	Group string
 	// Tags
 	Tags []string
 }

--- a/docs/script/configtypes.go
+++ b/docs/script/configtypes.go
@@ -34,6 +34,7 @@ func writeDocs() error {
 		{"mount.rst", config.MountConfig{}},
 		{"job.rst", config.JobConfig{}},
 		{"env.rst", config.EnvConfig{}},
+		{"annotationfields.rst", config.AnnotationFields{}},
 	} {
 		fmt.Printf("Generating doc %q\n", basePath+item.filename)
 		if err := write(basePath+item.filename, item.source); err != nil {

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -33,3 +33,6 @@ Each resource must be one of the following resource types:
 
 
 .. include:: ../gen/config/meta.rst
+
+
+.. include:: ../gen/config/annotationfields.rst


### PR DESCRIPTION
This feature adds the option `-g` / `--groups` to the list command.
Allowing a group setting in the annotations field lets group certain things together.

example dobi file:
```
meta:
  project: test

image=bash:
  image: bash
  pull: once
  tags:
    - latest

job=group1-1-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for group 1.1"
    group: group1

job=group1-2-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for group 1.1"
    group: group1

job=no-group-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for no group"

job=group2-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "teset job for group 2"
    group: group2

```
Resulting behavior with `-g` flag
```
./dobi -f test.yaml list -g                     
Resources:
  no-group-job         test job for no group
Group: group1
  group1-1-job         test job for group 1.1
  group1-2-job         test job for group 1.1
Group: group2
  group2-job           teset job for group 2
```

The old behavior is still present without `-g` flag.
```
./dobi -f test.yaml list   
Resources:
  group1-1-job         test job for group 1.1
  group1-2-job         test job for group 1.1
  group2-job           teset job for group 2
  no-group-job         test job for no group
```

If there are no groups defined but list is called with `-g`, it looks like if it were run without `-g`.
