### PR TITLE
List per tags

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,7 +43,8 @@ func newListCommand(opts *dobiOptions) *cobra.Command {
 		"List all resources, including those without descriptions")
 	flags.BoolVarP(
 		&listOpts.groups, "groups", "g", false,
-		"List resources sorted by their matching tags. Only resources with configured tags will be listed.")
+		"List resources sorted by their matching tags. Only resources"+
+			"with configured tags will be listed.")
 	flags.StringSliceVarP(
 		&listOpts.tags, "tags", "t", nil,
 		"List tasks matching the tag")
@@ -77,6 +78,7 @@ func runList(opts *dobiOptions, listOpts listOptions) error {
 func filterResourcesTags(conf *config.Config, listOpts listOptions) []resourceGroup {
 	tags := []resourceGroup{}
 	if listOpts.all {
+		// Add 'none' tag group accessible via [0] for resources with no tags configured
 		tags = append(tags, resourceGroup{tag: "none"})
 	}
 	for _, name := range conf.Sorted() {
@@ -92,11 +94,19 @@ func filterResourcesTags(conf *config.Config, listOpts listOptions) []resourceGr
 					})
 					currentGroupIndex = len(tags) - 1
 				}
-				tags[currentGroupIndex].resources = append(tags[currentGroupIndex].resources, namedResource{name: name, resource: res})
+				tags[currentGroupIndex].resources = append(tags[currentGroupIndex].resources,
+					namedResource{
+						name:     name,
+						resource: res,
+					})
 			}
 		} else {
 			if listOpts.all {
-				tags[0].resources = append(tags[0].resources, namedResource{name: name, resource: res})
+				tags[0].resources = append(tags[0].resources,
+					namedResource{
+						name:     name,
+						resource: res,
+					})
 			}
 		}
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,7 +43,7 @@ func newListCommand(opts *dobiOptions) *cobra.Command {
 		"List all resources, including those without descriptions")
 	flags.BoolVarP(
 		&listOpts.groups, "groups", "g", false,
-		"List resources sorted by their matching tags")
+		"List resources sorted by their matching tags. Only resources with configured tags will be listed.")
 	flags.StringSliceVarP(
 		&listOpts.tags, "tags", "t", nil,
 		"List tasks matching the tag")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,8 +12,9 @@ import (
 )
 
 type listOptions struct {
-	all  bool
-	tags []string
+	all    bool
+	groups bool
+	tags   []string
 }
 
 func (o listOptions) tagMatch(tags []string) bool {
@@ -40,6 +41,9 @@ func newListCommand(opts *dobiOptions) *cobra.Command {
 	flags.BoolVarP(
 		&listOpts.all, "all", "a", false,
 		"List all resources, including those without descriptions")
+	flags.BoolVarP(
+		&listOpts.groups, "groups", "g", false,
+		"List resources sorted by their matching tags")
 	flags.StringSliceVarP(
 		&listOpts.tags, "tags", "t", nil,
 		"List tasks matching the tag")
@@ -52,17 +56,52 @@ func runList(opts *dobiOptions, listOpts listOptions) error {
 		return err
 	}
 
-	resources := filterResources(conf, listOpts)
-	descriptions := getDescriptions(resources)
+	tags := getTags(conf.Resources)
+	var descriptions []string
+	if listOpts.groups {
+		resources := filterResourcesTags(conf, listOpts)
+		descriptions = getDescriptionsByTag(resources)
+	} else {
+		resources := filterResources(conf, listOpts)
+		descriptions = getDescriptions(resources)
+	}
+
 	if len(descriptions) == 0 {
 		logging.Log.Warn("No resources found. Try --all or --tags.")
 		return nil
 	}
-
-	tags := getTags(conf.Resources)
-
 	fmt.Print(format(descriptions, tags))
 	return nil
+}
+
+func filterResourcesTags(conf *config.Config, listOpts listOptions) []resourceGroup {
+	tags := []resourceGroup{}
+	if listOpts.all {
+		tags = append(tags, resourceGroup{tag: "none"})
+	}
+	for _, name := range conf.Sorted() {
+		res := conf.Resources[name]
+		if len(res.CategoryTags()) > 0 {
+			for _, tagname := range res.CategoryTags() {
+				currentGroupIndex := 0
+				if i, found := findGroup(tags, tagname); found {
+					currentGroupIndex = i
+				} else {
+					tags = append(tags, resourceGroup{
+						tag: tagname,
+					})
+					currentGroupIndex = len(tags) - 1
+				}
+				tags[currentGroupIndex].resources = append(tags[currentGroupIndex].resources, namedResource{name: name, resource: res})
+			}
+		} else {
+			if listOpts.all {
+				tags[0].resources = append(tags[0].resources, namedResource{name: name, resource: res})
+			}
+		}
+	}
+
+	return tags
 }
 
 func filterResources(conf *config.Config, listOpts listOptions) []namedResource {
@@ -74,6 +113,11 @@ func filterResources(conf *config.Config, listOpts listOptions) []namedResource 
 		}
 	}
 	return resources
+}
+
+type resourceGroup struct {
+	tag       string
+	resources []namedResource
 }
 
 type namedResource struct {
@@ -105,6 +149,15 @@ func getDescriptions(resources []namedResource) []string {
 	return lines
 }
 
+func getDescriptionsByTag(resources []resourceGroup) []string {
+	lines := []string{}
+	for _, tag := range resources {
+		descriptions := getDescriptions(tag.resources)
+		lines = append(lines, formatTags(tag.tag, descriptions))
+	}
+	return lines
+}
+
 func getTags(resources map[string]config.Resource) []string {
 	mapped := make(map[string]struct{})
 	for _, res := range resources {
@@ -120,6 +173,15 @@ func getTags(resources map[string]config.Resource) []string {
 	return tags
 }
 
+func findGroup(slice []resourceGroup, tag string) (int, bool) {
+	for i, item := range slice {
+		if item.tag == tag {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
 func format(descriptions []string, tags []string) string {
 	resources := strings.Join(descriptions, "\n  ")
 
@@ -127,5 +189,12 @@ func format(descriptions []string, tags []string) string {
 	if len(tags) > 0 {
 		msg += fmt.Sprintf("\nTags:\n  %s\n", strings.Join(tags, ", "))
 	}
+	return msg
+}
+
+func formatTags(tag string, descriptions []string) string {
+	msg := fmt.Sprintf("Tag: %s\n", tag)
+	resources := strings.Join(descriptions, "\n  ")
+	msg += fmt.Sprintf("  %s\n", resources)
 	return msg
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,9 +12,9 @@ import (
 )
 
 type listOptions struct {
-	all    bool
-	groups bool
-	tags   []string
+	all     bool
+	grouped bool
+	tags    []string
 }
 
 func (o listOptions) tagMatch(tags []string) bool {
@@ -42,8 +42,8 @@ func newListCommand(opts *dobiOptions) *cobra.Command {
 		&listOpts.all, "all", "a", false,
 		"List all resources, including those without descriptions")
 	flags.BoolVarP(
-		&listOpts.groups, "groups", "g", false,
-		"List resources sorted by their matching tags. Only resources"+
+		&listOpts.grouped, "grouped", "g", false,
+		"List resources grouped by tag. Only resources "+
 			"with configured tags will be listed.")
 	flags.StringSliceVarP(
 		&listOpts.tags, "tags", "t", nil,
@@ -59,7 +59,7 @@ func runList(opts *dobiOptions, listOpts listOptions) error {
 
 	tags := getTags(conf.Resources)
 	var descriptions []string
-	if listOpts.groups {
+	if listOpts.grouped {
 		resources := filterResourcesTags(conf, listOpts)
 		descriptions = getDescriptionsByTag(resources)
 	} else {

--- a/config/resource.go
+++ b/config/resource.go
@@ -55,7 +55,9 @@ type AnnotationFields struct {
 	// Description Description of the resource. Adding a description to a
 	// resource makes it visible from ``dobi list``.
 	Description string
-	// Tags
+	// Tags Tags can be used to group resources. There can be configured
+	// multiple tags per resource. Adding a tag to a resource outputs a
+	// grouped list from ``dobi list -g``.
 	Tags []string
 }
 

--- a/config/resource.go
+++ b/config/resource.go
@@ -41,7 +41,9 @@ func (a *Annotations) CategoryTags() []string {
 // ValidateDescription prints a warning if set
 func (a *Annotations) ValidateDescription() error {
 	if a.Description != "" && a.Annotations.Description != "" {
-		return errors.Errorf("deprecated description will be ignored in favor of annotations.description")
+		return errors.Errorf(
+			"deprecated description will be ignored in" +
+				"favor of annotations.description")
 	}
 	if a.Description != "" {
 		logging.Log.Warn("description is deprecated. Use annotations.description")

--- a/config/resource.go
+++ b/config/resource.go
@@ -42,7 +42,7 @@ func (a *Annotations) CategoryTags() []string {
 func (a *Annotations) ValidateDescription() error {
 	if a.Description != "" && a.Annotations.Description != "" {
 		return errors.Errorf(
-			"deprecated description will be ignored in" +
+			"deprecated description will be ignored in " +
 				"favor of annotations.description")
 	}
 	if a.Description != "" {

--- a/config/resource.go
+++ b/config/resource.go
@@ -41,8 +41,7 @@ func (a *Annotations) CategoryTags() []string {
 // ValidateDescription prints a warning if set
 func (a *Annotations) ValidateDescription() error {
 	if a.Description != "" && a.Annotations.Description != "" {
-		return errors.Errorf(
-			"deprecated description will be ignored in favor of annotations.description")
+		return errors.Errorf("deprecated description will be ignored in favor of annotations.description")
 	}
 	if a.Description != "" {
 		logging.Log.Warn("description is deprecated. Use annotations.description")

--- a/docs/script/configtypes.go
+++ b/docs/script/configtypes.go
@@ -34,6 +34,7 @@ func writeDocs() error {
 		{"mount.rst", config.MountConfig{}},
 		{"job.rst", config.JobConfig{}},
 		{"env.rst", config.EnvConfig{}},
+		{"annotationFields.rst", config.AnnotationFields{}},
 	} {
 		fmt.Printf("Generating doc %q\n", basePath+item.filename)
 		if err := write(basePath+item.filename, item.source); err != nil {

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -33,3 +33,6 @@ Each resource must be one of the following resource types:
 
 
 .. include:: ../gen/config/meta.rst
+
+
+.. include:: ../gen/config/annotationFields.rst


### PR DESCRIPTION
In reference to #207 this is a PR that implements the grouped list via tags.
Also this PR adds documentation to the AnnotationFields type. 

See for yourself below.

dobi.yaml
```
meta:
  project: test

image=bash:
  image: bash
  pull: once
  tags:
    - latest

job=group1-1-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for group 1.1"
    tags: 
      - group1

job=group1-2-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for group 1.1"
    tags: 
      - group1

job=no-group-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for no group"

job=group2-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for group 2"
    tags: 
      - group2

job=group1and2-job:
  use: bash
  command: bash -c "ls"
  annotations:
    description: "test job for group 1 and 2"
    tags: 
      - group1
      - group2

```
Usage:
```
./dobi -f test.yaml list --help  
List resources

Usage:
  dobi list [flags]

Flags:
  -a, --all            List all resources, including those without descriptions
  -g, --groups         List resources sorted by their matching tags. Only resources with configured tags will be listed.
  -t, --tags strings   List tasks matching the tag

```

Original output
```
./dobi -f test.yaml list      
Resources:
  group1-1-job         test job for group 1.1
  group1-2-job         test job for group 1.1
  group1and2-job       test job for group 1 and 2
  group2-job           test job for group 2
  no-group-job         test job for no group

Tags:
  group1, group2
```

Grouped list:
```
./dobi -f test.yaml list -g     
Resources:
  Tag: group1
  group1-1-job         test job for group 1.1
  group1-2-job         test job for group 1.1
  group1and2-job       test job for group 1 and 2

  Tag: group2
  group1and2-job       test job for group 1 and 2
  group2-job           test job for group 2


Tags:
  group1, group2
```

Grouped list with `all`:
```
./dobi -f test.yaml list -g -a
Resources:
  Tag: none
  bash                 Build image 'bash' from ''
  no-group-job         test job for no group

  Tag: group1
  group1-1-job         test job for group 1.1
  group1-2-job         test job for group 1.1
  group1and2-job       test job for group 1 and 2

  Tag: group2
  group1and2-job       test job for group 1 and 2
  group2-job           test job for group 2


Tags:
  group1, group2
```
