### PR TITLE
Fix sources/artifacts bug introduced with #184

### DIFF
--- a/execenv/environment.go
+++ b/execenv/environment.go
@@ -94,7 +94,7 @@ func (e *ExecEnv) templateContext(out io.Writer, tag string) (int, error) {
 	case "time":
 		return write(fmtdate.Format(suffix, e.startTime), nil)
 	case "fs":
-		val, err := valueFromFilesystem(suffix, e.workingDir)
+		val, err := ValueFromFilesystem(suffix, e.workingDir)
 		return write(val, err)
 	case "user":
 		val, err := valueFromUser(suffix)
@@ -113,7 +113,8 @@ func (e *ExecEnv) templateContext(out io.Writer, tag string) (int, error) {
 	}
 }
 
-func valueFromFilesystem(name string, workingdir string) (string, error) {
+// ValueFromFilesystem can return either `cwd` or `projectdir`
+func ValueFromFilesystem(name string, workingdir string) (string, error) {
 	switch name {
 	case "cwd":
 		return os.Getwd()

--- a/execenv/environment.go
+++ b/execenv/environment.go
@@ -94,7 +94,7 @@ func (e *ExecEnv) templateContext(out io.Writer, tag string) (int, error) {
 	case "time":
 		return write(fmtdate.Format(suffix, e.startTime), nil)
 	case "fs":
-		val, err := ValueFromFilesystem(suffix, e.workingDir)
+		val, err := valueFromFilesystem(suffix, e.workingDir)
 		return write(val, err)
 	case "user":
 		val, err := valueFromUser(suffix)
@@ -113,8 +113,8 @@ func (e *ExecEnv) templateContext(out io.Writer, tag string) (int, error) {
 	}
 }
 
-// ValueFromFilesystem can return either `cwd` or `projectdir`
-func ValueFromFilesystem(name string, workingdir string) (string, error) {
+// valueFromFilesystem can return either `cwd` or `projectdir`
+func valueFromFilesystem(name string, workingdir string) (string, error) {
 	switch name {
 	case "cwd":
 		return os.Getwd()

--- a/tasks/context/execcontext.go
+++ b/tasks/context/execcontext.go
@@ -69,7 +69,6 @@ func NewExecuteContext(
 	execEnv *execenv.ExecEnv,
 	settings Settings,
 ) *ExecuteContext {
-
 	authConfigs, err := docker.NewAuthConfigurationsFromDockerCfg()
 	if err != nil {
 		logging.Log.Warnf("Failed to load auth config: %s", err)

--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/dnephin/dobi/config"
@@ -78,7 +77,7 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 	excludes = append(excludes, ".dobi")
 
 	mtime, err := fs.LastModified(&fs.LastModifiedSearch{
-		Root:     filepath.Join(ctx.WorkingDir, t.config.Context),
+		Root:     ctx.WorkingDir,
 		Excludes: excludes,
 		Paths:    paths,
 	})

--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/dnephin/dobi/config"
@@ -77,7 +78,7 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 	excludes = append(excludes, ".dobi")
 
 	mtime, err := fs.LastModified(&fs.LastModifiedSearch{
-		Root:     ctx.WorkingDir,
+		Root:     absPath(ctx.WorkingDir, t.config.Context),
 		Excludes: excludes,
 		Paths:    paths,
 	})
@@ -101,6 +102,13 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func absPath(path string, wd string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(wd, path)
 }
 
 func buildImage(ctx *context.ExecuteContext, t *Task) error {

--- a/tasks/image/build.go
+++ b/tasks/image/build.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/dnephin/dobi/config"
@@ -77,7 +78,7 @@ func buildIsStale(ctx *context.ExecuteContext, t *Task) (bool, error) {
 	excludes = append(excludes, ".dobi")
 
 	mtime, err := fs.LastModified(&fs.LastModifiedSearch{
-		Root:     t.config.Context,
+		Root:     filepath.Join(ctx.WorkingDir, t.config.Context),
 		Excludes: excludes,
 		Paths:    paths,
 	})

--- a/tasks/job/run.go
+++ b/tasks/job/run.go
@@ -101,7 +101,7 @@ func (t *Task) isStale(ctx *context.ExecuteContext) (bool, error) {
 		return true, nil
 	}
 
-	artifactLastModified, err := t.artifactLastModified()
+	artifactLastModified, err := t.artifactLastModified(ctx.WorkingDir)
 	if err != nil {
 		t.logger().Warnf("Failed to get artifact last modified: %s", err)
 		return true, err
@@ -114,6 +114,7 @@ func (t *Task) isStale(ctx *context.ExecuteContext) (bool, error) {
 
 	if len(t.config.Sources.Paths()) != 0 {
 		sourcesLastModified, err := fs.LastModified(&fs.LastModifiedSearch{
+			Root:  ctx.WorkingDir,
 			Paths: t.config.Sources.Paths(),
 		})
 		if err != nil {
@@ -149,13 +150,13 @@ func (t *Task) isStale(ctx *context.ExecuteContext) (bool, error) {
 	return false, nil
 }
 
-func (t *Task) artifactLastModified() (time.Time, error) {
+func (t *Task) artifactLastModified(workDir string) (time.Time, error) {
 	paths := t.config.Artifact.Paths()
 	// File or directory doesn't exist
 	if len(paths) == 0 {
 		return time.Time{}, nil
 	}
-	return fs.LastModified(&fs.LastModifiedSearch{Paths: paths})
+	return fs.LastModified(&fs.LastModifiedSearch{Root: workDir, Paths: paths})
 }
 
 // TODO: support a .mountignore file used to ignore mtime of files
@@ -164,7 +165,7 @@ func (t *Task) mountsLastModified(ctx *context.ExecuteContext) (time.Time, error
 	ctx.Resources.EachMount(t.config.Mounts, func(name string, mount *config.MountConfig) {
 		mountPaths = append(mountPaths, mount.Bind)
 	})
-	return fs.LastModified(&fs.LastModifiedSearch{Paths: mountPaths})
+	return fs.LastModified(&fs.LastModifiedSearch{Root: ctx.WorkingDir, Paths: mountPaths})
 }
 
 func (t *Task) runContainerWithBinds(ctx *context.ExecuteContext) error {

--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	execenv "github.com/dnephin/dobi/execenv"
 	"github.com/docker/docker/pkg/fileutils"
 )
 
@@ -36,6 +34,15 @@ func LastModified(search *LastModifiedSearch) (time.Time, error) {
 		}
 	}
 
+	// Make absolute path out of `rootPath` to ensure proper functionality later on
+	if !filepath.IsAbs(rootPath) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return time.Time{}, err
+		}
+		rootPath = cwd + string(os.PathSeparator) + rootPath
+	}
+
 	pm, err := fileutils.NewPatternMatcher(search.Excludes)
 	if err != nil {
 		return time.Time{}, err
@@ -47,18 +54,6 @@ func LastModified(search *LastModifiedSearch) (time.Time, error) {
 				return fmt.Errorf("can't stat '%s'", filePath)
 			}
 			return err
-		}
-		// Append the cwd if the paths are relative. This is needed because
-		// source/artifact handling (`filepath.Rel()`) needs absolute paths to work properly.
-		cwd, err := execenv.ValueFromFilesystem("cwd", "")
-		if err != nil {
-			return err
-		}
-		if !strings.HasPrefix(rootPath, "/") {
-			rootPath = cwd + "/" + rootPath
-		}
-		if !strings.HasPrefix(filePath, "/") {
-			filePath = cwd + "/" + filePath
 		}
 		if relFilePath, err := filepath.Rel(rootPath, filePath); err != nil {
 			return err
@@ -77,21 +72,21 @@ func LastModified(search *LastModifiedSearch) (time.Time, error) {
 	}
 
 	for _, path := range search.Paths {
+		// Append the cwd if `path` is relative. This is needed because
+		// source/artifact handling (`filepath.Rel()`) needs absolute paths to work properly.
+		if !filepath.IsAbs(path) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return time.Time{}, err
+			}
+			path = cwd + string(os.PathSeparator) + path
+		}
 		info, err := os.Stat(path)
 		if err != nil {
 			return latest, err
 		}
 		switch info.IsDir() {
 		case false:
-			// Append the cwd if the path is relative. This is needed because
-			// source/artifact handling (`filepath.Rel()`) needs absolute paths to work properly.
-			if !strings.HasPrefix(path, "/") {
-				cwd, err := execenv.ValueFromFilesystem("cwd", "")
-				if err != nil {
-					return time.Time{}, err
-				}
-				path = cwd + "/" + path
-			}
 			if relPath, err := filepath.Rel(rootPath, path); err != nil {
 				return time.Time{}, err
 			} else if skip, err := filepathMatches(pm, relPath); err != nil {

--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -12,6 +12,9 @@ import (
 // LastModifiedSearch provides the means by which to specify your search parameters when
 // finding the last modified file.
 type LastModifiedSearch struct {
+	// Root must be set to the absolute path of the directory to traverse. Any
+	// relative paths in Paths and Excludes will be considered relative to this
+	// root directory.
 	Root     string
 	Excludes []string
 	Paths    []string
@@ -24,28 +27,23 @@ type LastModifiedSearch struct {
 // nolint: gocyclo
 func LastModified(search *LastModifiedSearch) (time.Time, error) {
 	var latest time.Time
-	var rootPath string
 	var err error
-
-	rootPath = search.Root
-	if rootPath == "" {
-		if rootPath, err = os.Getwd(); err != nil {
-			return time.Time{}, err
-		}
-	}
-
-	// Make absolute path out of `rootPath` to ensure proper functionality later on
-	if !filepath.IsAbs(rootPath) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return time.Time{}, err
-		}
-		rootPath = cwd + string(os.PathSeparator) + rootPath
-	}
 
 	pm, err := fileutils.NewPatternMatcher(search.Excludes)
 	if err != nil {
 		return time.Time{}, err
+	}
+
+	isExcluded := func(path string) (bool, error) {
+		relPath, err := filepath.Rel(search.Root, path)
+		if err != nil {
+			return false, err
+		}
+		if relPath == "." {
+			// Don't let them exclude everything, kind of silly.
+			return false, nil
+		}
+		return pm.Matches(relPath)
 	}
 
 	walker := func(filePath string, info os.FileInfo, err error) error {
@@ -55,16 +53,18 @@ func LastModified(search *LastModifiedSearch) (time.Time, error) {
 			}
 			return err
 		}
-		if relFilePath, err := filepath.Rel(rootPath, filePath); err != nil {
+
+		skip, err := isExcluded(filePath)
+		switch {
+		case err != nil:
 			return err
-		} else if skip, err := filepathMatches(pm, relFilePath); err != nil {
-			return err
-		} else if skip {
+		case skip:
 			if info.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
 		}
+
 		if info.ModTime().After(latest) {
 			latest = info.ModTime()
 		}
@@ -72,28 +72,24 @@ func LastModified(search *LastModifiedSearch) (time.Time, error) {
 	}
 
 	for _, path := range search.Paths {
-		// Append the cwd if `path` is relative. This is needed because
-		// source/artifact handling (`filepath.Rel()`) needs absolute paths to work properly.
 		if !filepath.IsAbs(path) {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return time.Time{}, err
-			}
-			path = cwd + string(os.PathSeparator) + path
+			path = filepath.Join(search.Root, path)
 		}
+
 		info, err := os.Stat(path)
 		if err != nil {
-			return latest, err
+			return latest, fmt.Errorf("internal error: %w", err)
 		}
 		switch info.IsDir() {
 		case false:
-			if relPath, err := filepath.Rel(rootPath, path); err != nil {
+			skip, err := isExcluded(path)
+			switch {
+			case err != nil:
 				return time.Time{}, err
-			} else if skip, err := filepathMatches(pm, relPath); err != nil {
-				return time.Time{}, err
-			} else if skip {
+			case skip:
 				continue
 			}
+
 			if info.ModTime().After(latest) {
 				latest = info.ModTime()
 				continue
@@ -105,13 +101,4 @@ func LastModified(search *LastModifiedSearch) (time.Time, error) {
 		}
 	}
 	return latest, nil
-}
-
-func filepathMatches(matcher *fileutils.PatternMatcher, file string) (bool, error) {
-	file = filepath.Clean(file)
-	if file == "." {
-		// Don't let them exclude everything, kind of silly.
-		return false, nil
-	}
-	return matcher.Matches(file)
 }

--- a/utils/fs/directory_test.go
+++ b/utils/fs/directory_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func TestLastModifiedAbsolutePathsForDirectories(t *testing.T) {
+func TestLastModified_AbsolutePathsForDirectories(t *testing.T) {
 	tmpdir := fs.NewDir(t, "test-directory-last-modified-absolute-paths-for-dir",
 		fs.WithDir("a"),
 		fs.WithDir("b",
@@ -20,7 +19,7 @@ func TestLastModifiedAbsolutePathsForDirectories(t *testing.T) {
 
 	for index, dir := range []string{"a", "b", "b/c"} {
 		mtime := time.Now().AddDate(0, 0, index+10)
-		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), mtime)))
+		assert.NilError(t, touch(tmpdir.Join(dir, "file"), mtime))
 
 		actual, err := LastModified(&LastModifiedSearch{
 			Root:  tmpdir.Path(),
@@ -31,20 +30,20 @@ func TestLastModifiedAbsolutePathsForDirectories(t *testing.T) {
 	}
 }
 
-func TestLastModifiedRelativePathsForDirectories(t *testing.T) {
+func TestLastModified_RelativePathsForDirectories(t *testing.T) {
 	tmpdir := fs.NewDir(t, "test-directory-last-modified-relative-paths-for-dir",
-		fs.WithDir("a"),
-		fs.WithDir("b",
-			fs.WithDir("c")))
+		fs.WithDir("inner",
+			fs.WithDir("a"),
+			fs.WithDir("b",
+				fs.WithDir("c"))))
 	defer tmpdir.Remove()
-	assert.NilError(t, os.Chdir(filepath.Join(tmpdir.Path())))
 
 	for index, dir := range []string{"a", "b", "b/c"} {
 		mtime := time.Now().AddDate(0, 0, index+10)
-		assert.Assert(t, cmp.Nil(touch(tmpdir.Join(dir, "file"), mtime)))
+		assert.NilError(t, touch(tmpdir.Join("inner", dir, "file"), mtime))
 
 		actual, err := LastModified(&LastModifiedSearch{
-			Root:  tmpdir.Path(),
+			Root:  tmpdir.Join("inner"),
 			Paths: []string{"a", "b", "b/c"},
 		})
 		assert.NilError(t, err)
@@ -52,17 +51,17 @@ func TestLastModifiedRelativePathsForDirectories(t *testing.T) {
 	}
 }
 
-func TestLastModifiedRelativePathsForFile(t *testing.T) {
+func TestLastModified_RelativePathsForFile(t *testing.T) {
 	tmpdir := fs.NewDir(t, "test-directory-last-modified-relative-paths-for-file",
-		fs.WithDir("a"))
+		fs.WithDir("inner",
+			fs.WithDir("a")))
 	defer tmpdir.Remove()
-	assert.NilError(t, os.Chdir(filepath.Join(tmpdir.Path())))
 
 	mtime := time.Now().AddDate(0, 0, 10)
-	assert.Assert(t, cmp.Nil(touch(tmpdir.Join("a", "file"), mtime)))
+	assert.NilError(t, touch(tmpdir.Join("inner", "a", "file"), mtime))
 
 	actual, err := LastModified(&LastModifiedSearch{
-		Root:  tmpdir.Path(),
+		Root:  tmpdir.Join("inner"),
 		Paths: []string{"a/file"},
 	})
 	assert.NilError(t, err)


### PR DESCRIPTION
This fixes issue #200. The file handling introduced with #184 relies on absolute paths. 

It checks if the path is relative. If so, prepent the `cwd` to the path.
e.g. 
```
job=build:
    use: builder
    sources: 
      - source/*.cpp
...
```
In the above example the paths in sources are relative. They are located within the project where the dobi.yaml is located. So internally it creates `<cwd>/source/*.cpp`. 